### PR TITLE
Reformat with clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -7,9 +7,6 @@ UseTab: Never
 
 ColumnLimit: 120
 
-PointerAlignment: Right
-DerivePointerAlignment: false
-
 IncludeBlocks: Regroup
 IncludeCategories:
   - Regex: '^".*"$'

--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,22 @@
+BasedOnStyle: LLVM
+
+IndentWidth: 4
+ContinuationIndentWidth: 6
+TabWidth: 4
+UseTab: Never
+
+ColumnLimit: 120
+
+PointerAlignment: Right
+DerivePointerAlignment: false
+
+IncludeBlocks: Regroup
+IncludeCategories:
+  - Regex: '^".*"$'
+    Priority: 1
+  - Regex: '^<(Foundation|AVFAudio)/'
+    Priority: 3
+  - Regex: '^<[^./>]+>$'
+    Priority: 10
+  - Regex: '.*'
+    Priority: 20

--- a/Sources/AVFAudioExtensions/AVAudioChannelLayout+SFBChannelLabels.m
+++ b/Sources/AVFAudioExtensions/AVAudioChannelLayout+SFBChannelLabels.m
@@ -12,163 +12,157 @@
 #import <stdlib.h>
 #import <string.h>
 
-static size_t GetChannelLayoutSize(UInt32 numberChannelDescriptions)
-{
-	return offsetof(AudioChannelLayout, mChannelDescriptions) + (numberChannelDescriptions * sizeof(AudioChannelDescription));
+static size_t GetChannelLayoutSize(UInt32 numberChannelDescriptions) {
+    return offsetof(AudioChannelLayout, mChannelDescriptions) +
+           (numberChannelDescriptions * sizeof(AudioChannelDescription));
 }
 
-static AudioChannelLayout * CreateChannelLayout(UInt32 numberChannelDescriptions)
-{
-	size_t layoutSize = GetChannelLayoutSize(numberChannelDescriptions);
-	AudioChannelLayout *channelLayout = malloc(layoutSize);
-	if(!channelLayout)
-		return NULL;
+static AudioChannelLayout *CreateChannelLayout(UInt32 numberChannelDescriptions) {
+    size_t layoutSize = GetChannelLayoutSize(numberChannelDescriptions);
+    AudioChannelLayout *channelLayout = malloc(layoutSize);
+    if (!channelLayout)
+        return NULL;
 
-	memset(channelLayout, 0, layoutSize);
+    memset(channelLayout, 0, layoutSize);
 
-	return channelLayout;
+    return channelLayout;
 }
 
-static AudioChannelLabel ChannelLabelForString(NSString *s)
-{
-	static NSDictionary *labels = nil;
-	static dispatch_once_t onceToken;
-	dispatch_once(&onceToken, ^{
-		labels = @{
-			@"l"	: @(kAudioChannelLabel_Left),
-			@"r"	: @(kAudioChannelLabel_Right),
-			@"c"	: @(kAudioChannelLabel_Center),
-			@"lfe"	: @(kAudioChannelLabel_LFEScreen),
-			@"ls"	: @(kAudioChannelLabel_LeftSurround),
-			@"rs"	: @(kAudioChannelLabel_RightSurround),
-			@"lc"	: @(kAudioChannelLabel_LeftCenter),
-			@"rc"	: @(kAudioChannelLabel_RightCenter),
-			@"cs"	: @(kAudioChannelLabel_CenterSurround),
-			@"lsd"	: @(kAudioChannelLabel_LeftSurroundDirect),
-			@"rsd"	: @(kAudioChannelLabel_RightSurroundDirect),
-			@"tcs"	: @(kAudioChannelLabel_TopCenterSurround),
-			@"vhl"	: @(kAudioChannelLabel_VerticalHeightLeft),
-			@"vhc"	: @(kAudioChannelLabel_VerticalHeightCenter),
-			@"vhr"	: @(kAudioChannelLabel_VerticalHeightRight),
+static AudioChannelLabel ChannelLabelForString(NSString *s) {
+    static NSDictionary *labels = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+      labels = @{
+          @"l" : @(kAudioChannelLabel_Left),
+          @"r" : @(kAudioChannelLabel_Right),
+          @"c" : @(kAudioChannelLabel_Center),
+          @"lfe" : @(kAudioChannelLabel_LFEScreen),
+          @"ls" : @(kAudioChannelLabel_LeftSurround),
+          @"rs" : @(kAudioChannelLabel_RightSurround),
+          @"lc" : @(kAudioChannelLabel_LeftCenter),
+          @"rc" : @(kAudioChannelLabel_RightCenter),
+          @"cs" : @(kAudioChannelLabel_CenterSurround),
+          @"lsd" : @(kAudioChannelLabel_LeftSurroundDirect),
+          @"rsd" : @(kAudioChannelLabel_RightSurroundDirect),
+          @"tcs" : @(kAudioChannelLabel_TopCenterSurround),
+          @"vhl" : @(kAudioChannelLabel_VerticalHeightLeft),
+          @"vhc" : @(kAudioChannelLabel_VerticalHeightCenter),
+          @"vhr" : @(kAudioChannelLabel_VerticalHeightRight),
 
-			@"tbl"	: @(kAudioChannelLabel_TopBackLeft),
-			@"tbc"	: @(kAudioChannelLabel_TopBackCenter),
-			@"tbr"	: @(kAudioChannelLabel_TopBackRight),
+          @"tbl" : @(kAudioChannelLabel_TopBackLeft),
+          @"tbc" : @(kAudioChannelLabel_TopBackCenter),
+          @"tbr" : @(kAudioChannelLabel_TopBackRight),
 
-			@"rls"	: @(kAudioChannelLabel_RearSurroundLeft),
-			@"rrs"	: @(kAudioChannelLabel_RearSurroundRight),
+          @"rls" : @(kAudioChannelLabel_RearSurroundLeft),
+          @"rrs" : @(kAudioChannelLabel_RearSurroundRight),
 
-			@"lw"	: @(kAudioChannelLabel_LeftWide),
-			@"rw"	: @(kAudioChannelLabel_RightWide),
-		};
-	});
+          @"lw" : @(kAudioChannelLabel_LeftWide),
+          @"rw" : @(kAudioChannelLabel_RightWide),
+      };
+    });
 
-	NSNumber *label = [labels objectForKey:s];
-	if(label != nil)
-		return (AudioChannelLabel)label.unsignedIntValue;
-	return kAudioChannelLabel_Unknown;
+    NSNumber *label = [labels objectForKey:s];
+    if (label != nil)
+        return (AudioChannelLabel)label.unsignedIntValue;
+    return kAudioChannelLabel_Unknown;
 }
 
 @implementation AVAudioChannelLayout (SFBChannelLabels)
 
-+ (nullable instancetype)layoutWithChannelLabels:(AVAudioChannelCount)count, ...
-{
-	va_list ap;
-	va_start(ap, count);
++ (nullable instancetype)layoutWithChannelLabels:(AVAudioChannelCount)count, ... {
+    va_list ap;
+    va_start(ap, count);
 
-	AVAudioChannelLayout *layout = [[AVAudioChannelLayout alloc] initWithChannelLabels:count ap:ap];
+    AVAudioChannelLayout *layout = [[AVAudioChannelLayout alloc] initWithChannelLabels:count ap:ap];
 
-	va_end(ap);
+    va_end(ap);
 
-	return layout;
+    return layout;
 }
 
-+ (nullable instancetype)layoutWithChannelLabels:(const AudioChannelLabel *)channelLabels count:(AVAudioChannelCount)count
-{
-	return [[AVAudioChannelLayout alloc] initWithChannelLabels:channelLabels count:count];
++ (nullable instancetype)layoutWithChannelLabels:(const AudioChannelLabel *)channelLabels
+                                           count:(AVAudioChannelCount)count {
+    return [[AVAudioChannelLayout alloc] initWithChannelLabels:channelLabels count:count];
 }
 
-+ (instancetype)layoutWithChannelLabelString:(NSString *)channelLabelString
-{
-	return [[AVAudioChannelLayout alloc] initWithChannelLabelString:channelLabelString];
++ (instancetype)layoutWithChannelLabelString:(NSString *)channelLabelString {
+    return [[AVAudioChannelLayout alloc] initWithChannelLabelString:channelLabelString];
 }
 
-- (nullable instancetype)initWithChannelLabels:(AVAudioChannelCount)count, ...
-{
-	va_list ap;
-	va_start(ap, count);
+- (nullable instancetype)initWithChannelLabels:(AVAudioChannelCount)count, ... {
+    va_list ap;
+    va_start(ap, count);
 
-	self = [self initWithChannelLabels:count ap:ap];
+    self = [self initWithChannelLabels:count ap:ap];
 
-	va_end(ap);
+    va_end(ap);
 
-	return self;
+    return self;
 }
 
-- (nullable instancetype)initWithChannelLabels:(AVAudioChannelCount)count ap:(va_list)ap
-{
-	NSParameterAssert(count > 0);
-	NSParameterAssert(ap != NULL);
+- (nullable instancetype)initWithChannelLabels:(AVAudioChannelCount)count ap:(va_list)ap {
+    NSParameterAssert(count > 0);
+    NSParameterAssert(ap != NULL);
 
-	AudioChannelLabel *channelLabels = malloc(sizeof(AudioChannelLabel) * count);
-	if(!channelLabels)
-		return nil;
+    AudioChannelLabel *channelLabels = malloc(sizeof(AudioChannelLabel) * count);
+    if (!channelLabels)
+        return nil;
 
-	for(AVAudioChannelCount i = 0; i < count; ++i)
-		channelLabels[i] = va_arg(ap, AudioChannelLabel);
+    for (AVAudioChannelCount i = 0; i < count; ++i)
+        channelLabels[i] = va_arg(ap, AudioChannelLabel);
 
-	self = [self initWithChannelLabels:channelLabels count:count];
-	free(channelLabels);
-	return self;
+    self = [self initWithChannelLabels:channelLabels count:count];
+    free(channelLabels);
+    return self;
 }
 
-- (nullable instancetype)initWithChannelLabels:(const AudioChannelLabel *)channelLabels count:(AVAudioChannelCount)count
-{
-	NSParameterAssert(channelLabels != NULL);
-	NSParameterAssert(count > 0);
+- (nullable instancetype)initWithChannelLabels:(const AudioChannelLabel *)channelLabels
+                                         count:(AVAudioChannelCount)count {
+    NSParameterAssert(channelLabels != NULL);
+    NSParameterAssert(count > 0);
 
-	AudioChannelLayout *channelLayout = CreateChannelLayout(count);
-	if(!channelLayout)
-		return nil;
+    AudioChannelLayout *channelLayout = CreateChannelLayout(count);
+    if (!channelLayout)
+        return nil;
 
-	channelLayout->mChannelLayoutTag = kAudioChannelLayoutTag_UseChannelDescriptions;
-	channelLayout->mNumberChannelDescriptions = count;
+    channelLayout->mChannelLayoutTag = kAudioChannelLayoutTag_UseChannelDescriptions;
+    channelLayout->mNumberChannelDescriptions = count;
 
-	for(AVAudioChannelCount i = 0; i < count; ++i)
-		channelLayout->mChannelDescriptions[i].mChannelLabel = channelLabels[i];
+    for (AVAudioChannelCount i = 0; i < count; ++i)
+        channelLayout->mChannelDescriptions[i].mChannelLabel = channelLabels[i];
 
-	// Attempt to convert the channel labels to a layout tag
-	AudioChannelLayoutTag tag;
-	UInt32 dataSize = sizeof(tag);
-	OSStatus result = AudioFormatGetProperty(kAudioFormatProperty_TagForChannelLayout, (UInt32)GetChannelLayoutSize(count), channelLayout, &dataSize, &tag);
-	if(result == noErr)
-		self = [self initWithLayoutTag:tag];
-	else
-		self = [self initWithLayout:channelLayout];
+    // Attempt to convert the channel labels to a layout tag
+    AudioChannelLayoutTag tag;
+    UInt32 dataSize = sizeof(tag);
+    OSStatus result = AudioFormatGetProperty(kAudioFormatProperty_TagForChannelLayout,
+                                             (UInt32)GetChannelLayoutSize(count), channelLayout, &dataSize, &tag);
+    if (result == noErr)
+        self = [self initWithLayoutTag:tag];
+    else
+        self = [self initWithLayout:channelLayout];
 
-	free(channelLayout);
+    free(channelLayout);
 
-	return self;
+    return self;
 }
 
-- (nullable instancetype)initWithChannelLabelString:(NSString *)channelLabelString
-{
-	NSParameterAssert(channelLabelString != nil);
+- (nullable instancetype)initWithChannelLabelString:(NSString *)channelLabelString {
+    NSParameterAssert(channelLabelString != nil);
 
-	NSArray *channelLabelArray = [[channelLabelString lowercaseString] componentsSeparatedByString:@" "];
+    NSArray *channelLabelArray = [[channelLabelString lowercaseString] componentsSeparatedByString:@" "];
 
-	NSUInteger count = channelLabelArray.count;
+    NSUInteger count = channelLabelArray.count;
 
-	AudioChannelLabel *channelLabels = malloc(sizeof(AudioChannelLabel) * count);
-	if(!channelLabels)
-		return nil;
+    AudioChannelLabel *channelLabels = malloc(sizeof(AudioChannelLabel) * count);
+    if (!channelLabels)
+        return nil;
 
-	for(NSUInteger i = 0; i < count; ++i)
-		channelLabels[i] = ChannelLabelForString([channelLabelArray objectAtIndex:i]);
+    for (NSUInteger i = 0; i < count; ++i)
+        channelLabels[i] = ChannelLabelForString([channelLabelArray objectAtIndex:i]);
 
-	self = [self initWithChannelLabels:channelLabels count:(AVAudioChannelCount)count];
-	free(channelLabels);
-	return self;
+    self = [self initWithChannelLabels:channelLabels count:(AVAudioChannelCount)count];
+    free(channelLabels);
+    return self;
 }
 
 @end

--- a/Sources/AVFAudioExtensions/AVAudioChannelLayout+SFBLayoutNames.m
+++ b/Sources/AVFAudioExtensions/AVAudioChannelLayout+SFBLayoutNames.m
@@ -9,30 +9,29 @@
 
 @import AudioToolbox.AudioFormat;
 
-static NSString * GetLayoutName(const AudioChannelLayout *layout, BOOL simpleName)
-{
-	NSCParameterAssert(layout != NULL);
+static NSString *GetLayoutName(const AudioChannelLayout *layout, BOOL simpleName) {
+    NSCParameterAssert(layout != NULL);
 
-	AudioFormatPropertyID property = simpleName ? kAudioFormatProperty_ChannelLayoutSimpleName : kAudioFormatProperty_ChannelLayoutName;
-	UInt32 layoutSize = offsetof(AudioChannelLayout, mChannelDescriptions) + (layout->mNumberChannelDescriptions * sizeof(AudioChannelDescription));
-	CFStringRef name = NULL;
-	UInt32 dataSize = sizeof(name);
-	OSStatus result = AudioFormatGetProperty(property, layoutSize, layout, &dataSize, &name);
-	if(result != noErr || name == NULL)
-		return @"";
-	return (__bridge_transfer NSString *)name;
+    AudioFormatPropertyID property =
+          simpleName ? kAudioFormatProperty_ChannelLayoutSimpleName : kAudioFormatProperty_ChannelLayoutName;
+    UInt32 layoutSize = offsetof(AudioChannelLayout, mChannelDescriptions) +
+                        (layout->mNumberChannelDescriptions * sizeof(AudioChannelDescription));
+    CFStringRef name = NULL;
+    UInt32 dataSize = sizeof(name);
+    OSStatus result = AudioFormatGetProperty(property, layoutSize, layout, &dataSize, &name);
+    if (result != noErr || name == NULL)
+        return @"";
+    return (__bridge_transfer NSString *)name;
 }
 
 @implementation AVAudioChannelLayout (SFBLayoutNames)
 
-- (NSString *)layoutName
-{
-	return GetLayoutName(self.layout, NO);
+- (NSString *)layoutName {
+    return GetLayoutName(self.layout, NO);
 }
 
-- (NSString *)layoutSimpleName
-{
-	return GetLayoutName(self.layout, YES);
+- (NSString *)layoutSimpleName {
+    return GetLayoutName(self.layout, YES);
 }
 
 @end

--- a/Sources/AVFAudioExtensions/AVAudioFormat+SFBFormatName.m
+++ b/Sources/AVFAudioExtensions/AVAudioFormat+SFBFormatName.m
@@ -13,14 +13,14 @@
 
 @implementation AVAudioFormat (SFBFormatName)
 
-- (NSString *)formatName
-{
-	CFStringRef name = NULL;
-	UInt32 dataSize = sizeof(name);
-	OSStatus result = AudioFormatGetProperty(kAudioFormatProperty_FormatName, sizeof(AudioStreamBasicDescription), self.streamDescription, &dataSize, &name);
-	if(result != noErr || name == NULL)
-		return @"";
-	return (__bridge_transfer NSString *)name;
+- (NSString *)formatName {
+    CFStringRef name = NULL;
+    UInt32 dataSize = sizeof(name);
+    OSStatus result = AudioFormatGetProperty(kAudioFormatProperty_FormatName, sizeof(AudioStreamBasicDescription),
+                                             self.streamDescription, &dataSize, &name);
+    if (result != noErr || name == NULL)
+        return @"";
+    return (__bridge_transfer NSString *)name;
 }
 
 @end

--- a/Sources/AVFAudioExtensions/AVAudioFormat+SFBFormatTransformation.m
+++ b/Sources/AVFAudioExtensions/AVAudioFormat+SFBFormatTransformation.m
@@ -9,56 +9,59 @@
 
 @implementation AVAudioFormat (SFBFormatTransformation)
 
-- (nullable AVAudioFormat *)nonInterleavedEquivalent
-{
-	AudioStreamBasicDescription asbd = *(self.streamDescription);
-	if(asbd.mFormatID != kAudioFormatLinearPCM || !asbd.mChannelsPerFrame)
-		return nil;
+- (nullable AVAudioFormat *)nonInterleavedEquivalent {
+    AudioStreamBasicDescription asbd = *(self.streamDescription);
+    if (asbd.mFormatID != kAudioFormatLinearPCM || !asbd.mChannelsPerFrame)
+        return nil;
 
-	if(asbd.mFormatFlags & kAudioFormatFlagIsNonInterleaved)
-		return self;
+    if (asbd.mFormatFlags & kAudioFormatFlagIsNonInterleaved)
+        return self;
 
-	asbd.mFormatFlags |= kAudioFormatFlagIsNonInterleaved;
+    asbd.mFormatFlags |= kAudioFormatFlagIsNonInterleaved;
 
-	asbd.mBytesPerPacket /= asbd.mChannelsPerFrame;
-	asbd.mBytesPerFrame /= asbd.mChannelsPerFrame;
+    asbd.mBytesPerPacket /= asbd.mChannelsPerFrame;
+    asbd.mBytesPerFrame /= asbd.mChannelsPerFrame;
 
-	return [[AVAudioFormat alloc] initWithStreamDescription:&asbd channelLayout:self.channelLayout];
+    return [[AVAudioFormat alloc] initWithStreamDescription:&asbd channelLayout:self.channelLayout];
 }
 
-- (nullable AVAudioFormat *)interleavedEquivalent
-{
-	AudioStreamBasicDescription asbd = *(self.streamDescription);
-	if(asbd.mFormatID != kAudioFormatLinearPCM)
-		return nil;
+- (nullable AVAudioFormat *)interleavedEquivalent {
+    AudioStreamBasicDescription asbd = *(self.streamDescription);
+    if (asbd.mFormatID != kAudioFormatLinearPCM)
+        return nil;
 
-	if(!(asbd.mFormatFlags & kAudioFormatFlagIsNonInterleaved))
-		return self;
+    if (!(asbd.mFormatFlags & kAudioFormatFlagIsNonInterleaved))
+        return self;
 
-	asbd.mFormatFlags &= ~kAudioFormatFlagIsNonInterleaved;
+    asbd.mFormatFlags &= ~kAudioFormatFlagIsNonInterleaved;
 
-	asbd.mBytesPerPacket *= asbd.mChannelsPerFrame;
-	asbd.mBytesPerFrame *= asbd.mChannelsPerFrame;
+    asbd.mBytesPerPacket *= asbd.mChannelsPerFrame;
+    asbd.mBytesPerFrame *= asbd.mChannelsPerFrame;
 
-	return [[AVAudioFormat alloc] initWithStreamDescription:&asbd channelLayout:self.channelLayout];
+    return [[AVAudioFormat alloc] initWithStreamDescription:&asbd channelLayout:self.channelLayout];
 }
 
-- (nullable AVAudioFormat *)standardEquivalent
-{
-	if(self.isStandard)
-		return self;
-	else if(self.channelLayout)
-		return [[AVAudioFormat alloc] initStandardFormatWithSampleRate:self.sampleRate channelLayout:self.channelLayout];
-	else
-		return [[AVAudioFormat alloc] initStandardFormatWithSampleRate:self.sampleRate channels:self.channelCount];
+- (nullable AVAudioFormat *)standardEquivalent {
+    if (self.isStandard)
+        return self;
+    else if (self.channelLayout)
+        return [[AVAudioFormat alloc] initStandardFormatWithSampleRate:self.sampleRate
+                                                         channelLayout:self.channelLayout];
+    else
+        return [[AVAudioFormat alloc] initStandardFormatWithSampleRate:self.sampleRate channels:self.channelCount];
 }
 
-- (nullable AVAudioFormat *)transformedToCommonFormat:(AVAudioCommonFormat)commonFormat interleaved:(BOOL)interleaved
-{
-	if(self.channelLayout)
-		return [[AVAudioFormat alloc] initWithCommonFormat:commonFormat sampleRate:self.sampleRate interleaved:interleaved channelLayout:self.channelLayout];
-	else
-		return [[AVAudioFormat alloc] initWithCommonFormat:commonFormat sampleRate:self.sampleRate channels:self.channelCount interleaved:interleaved];
+- (nullable AVAudioFormat *)transformedToCommonFormat:(AVAudioCommonFormat)commonFormat interleaved:(BOOL)interleaved {
+    if (self.channelLayout)
+        return [[AVAudioFormat alloc] initWithCommonFormat:commonFormat
+                                                sampleRate:self.sampleRate
+                                               interleaved:interleaved
+                                             channelLayout:self.channelLayout];
+    else
+        return [[AVAudioFormat alloc] initWithCommonFormat:commonFormat
+                                                sampleRate:self.sampleRate
+                                                  channels:self.channelCount
+                                               interleaved:interleaved];
 }
 
 @end

--- a/Sources/AVFAudioExtensions/AVAudioPCMBuffer+SFBBufferUtilities.m
+++ b/Sources/AVFAudioExtensions/AVAudioPCMBuffer+SFBBufferUtilities.m
@@ -12,373 +12,390 @@
 
 @implementation AVAudioPCMBuffer (SFBBufferUtilities)
 
-- (AVAudioFrameCount)prependContentsOfBuffer:(AVAudioPCMBuffer *)buffer
-{
-	return [self insertFromBuffer:buffer readingFromOffset:0 frameLength:buffer.frameLength atOffset:0];
+- (AVAudioFrameCount)prependContentsOfBuffer:(AVAudioPCMBuffer *)buffer {
+    return [self insertFromBuffer:buffer readingFromOffset:0 frameLength:buffer.frameLength atOffset:0];
 }
 
-- (AVAudioFrameCount)prependFromBuffer:(AVAudioPCMBuffer *)buffer readingFromOffset:(AVAudioFrameCount)offset
-{
-	if(offset > buffer.frameLength)
-		return 0;
-	return [self insertFromBuffer:buffer readingFromOffset:offset frameLength:(buffer.frameLength - offset) atOffset:0];
+- (AVAudioFrameCount)prependFromBuffer:(AVAudioPCMBuffer *)buffer readingFromOffset:(AVAudioFrameCount)offset {
+    if (offset > buffer.frameLength)
+        return 0;
+    return [self insertFromBuffer:buffer readingFromOffset:offset frameLength:(buffer.frameLength - offset) atOffset:0];
 }
 
-- (AVAudioFrameCount)prependFromBuffer:(AVAudioPCMBuffer *)buffer readingFromOffset:(AVAudioFrameCount)offset frameLength:(AVAudioFrameCount)frameLength
-{
-	return [self insertFromBuffer:buffer readingFromOffset:offset frameLength:frameLength atOffset:0];
+- (AVAudioFrameCount)prependFromBuffer:(AVAudioPCMBuffer *)buffer
+                     readingFromOffset:(AVAudioFrameCount)offset
+                           frameLength:(AVAudioFrameCount)frameLength {
+    return [self insertFromBuffer:buffer readingFromOffset:offset frameLength:frameLength atOffset:0];
 }
 
-- (AVAudioFrameCount)appendContentsOfBuffer:(AVAudioPCMBuffer *)buffer
-{
-	return [self insertFromBuffer:buffer readingFromOffset:0 frameLength:buffer.frameLength atOffset:self.frameLength];
+- (AVAudioFrameCount)appendContentsOfBuffer:(AVAudioPCMBuffer *)buffer {
+    return [self insertFromBuffer:buffer readingFromOffset:0 frameLength:buffer.frameLength atOffset:self.frameLength];
 }
 
-- (AVAudioFrameCount)appendFromBuffer:(AVAudioPCMBuffer *)buffer readingFromOffset:(AVAudioFrameCount)offset
-{
-	if(offset > buffer.frameLength)
-		return 0;
-	return [self insertFromBuffer:buffer readingFromOffset:offset frameLength:(buffer.frameLength - offset) atOffset:self.frameLength];
+- (AVAudioFrameCount)appendFromBuffer:(AVAudioPCMBuffer *)buffer readingFromOffset:(AVAudioFrameCount)offset {
+    if (offset > buffer.frameLength)
+        return 0;
+    return [self insertFromBuffer:buffer
+                readingFromOffset:offset
+                      frameLength:(buffer.frameLength - offset)
+                         atOffset:self.frameLength];
 }
 
-- (AVAudioFrameCount)appendFromBuffer:(AVAudioPCMBuffer *)buffer readingFromOffset:(AVAudioFrameCount)offset frameLength:(AVAudioFrameCount)frameLength
-{
-	return [self insertFromBuffer:buffer readingFromOffset:offset frameLength:frameLength atOffset:self.frameLength];
+- (AVAudioFrameCount)appendFromBuffer:(AVAudioPCMBuffer *)buffer
+                    readingFromOffset:(AVAudioFrameCount)offset
+                          frameLength:(AVAudioFrameCount)frameLength {
+    return [self insertFromBuffer:buffer readingFromOffset:offset frameLength:frameLength atOffset:self.frameLength];
 }
 
-- (AVAudioFrameCount)insertContentsOfBuffer:(AVAudioPCMBuffer *)buffer atOffset:(AVAudioFrameCount)offset
-{
-	return [self insertFromBuffer:buffer readingFromOffset:0 frameLength:buffer.frameLength atOffset:offset];
+- (AVAudioFrameCount)insertContentsOfBuffer:(AVAudioPCMBuffer *)buffer atOffset:(AVAudioFrameCount)offset {
+    return [self insertFromBuffer:buffer readingFromOffset:0 frameLength:buffer.frameLength atOffset:offset];
 }
 
-- (AVAudioFrameCount)insertFromBuffer:(AVAudioPCMBuffer *)buffer readingFromOffset:(AVAudioFrameCount)readOffset frameLength:(AVAudioFrameCount)frameLength atOffset:(AVAudioFrameCount)writeOffset
-{
-	NSParameterAssert(buffer != nil);
-	NSParameterAssert([self.format isEqual:buffer.format]);
+- (AVAudioFrameCount)insertFromBuffer:(AVAudioPCMBuffer *)buffer
+                    readingFromOffset:(AVAudioFrameCount)readOffset
+                          frameLength:(AVAudioFrameCount)frameLength
+                             atOffset:(AVAudioFrameCount)writeOffset {
+    NSParameterAssert(buffer != nil);
+    NSParameterAssert([self.format isEqual:buffer.format]);
 
-	if(readOffset > buffer.frameLength || writeOffset > self.frameLength || frameLength == 0 || buffer.frameLength == 0)
-		return 0;
+    if (readOffset > buffer.frameLength || writeOffset > self.frameLength || frameLength == 0 ||
+        buffer.frameLength == 0)
+        return 0;
 
-	AVAudioFrameCount framesToInsert = MIN(self.frameCapacity - self.frameLength, MIN(frameLength, buffer.frameLength - readOffset));
+    AVAudioFrameCount framesToInsert =
+          MIN(self.frameCapacity - self.frameLength, MIN(frameLength, buffer.frameLength - readOffset));
 
-	const AudioStreamBasicDescription *asbd = self.format.streamDescription;
-	const AudioBufferList *src_abl = buffer.audioBufferList;
-	const AudioBufferList *dst_abl = self.audioBufferList;
+    const AudioStreamBasicDescription *asbd = self.format.streamDescription;
+    const AudioBufferList *src_abl = buffer.audioBufferList;
+    const AudioBufferList *dst_abl = self.audioBufferList;
 
-	AVAudioFrameCount framesToMove = self.frameLength - writeOffset;
-	if(framesToMove) {
-		AVAudioFrameCount moveToOffset = writeOffset + framesToInsert;
-		for(UInt32 i = 0; i < dst_abl->mNumberBuffers; ++i)
-			memmove((void *)((uintptr_t)dst_abl->mBuffers[i].mData + (moveToOffset * asbd->mBytesPerFrame)),
-					(const void *)((uintptr_t)dst_abl->mBuffers[i].mData + (writeOffset * asbd->mBytesPerFrame)),
-					framesToMove * asbd->mBytesPerFrame);
-	}
+    AVAudioFrameCount framesToMove = self.frameLength - writeOffset;
+    if (framesToMove) {
+        AVAudioFrameCount moveToOffset = writeOffset + framesToInsert;
+        for (UInt32 i = 0; i < dst_abl->mNumberBuffers; ++i)
+            memmove((void *)((uintptr_t)dst_abl->mBuffers[i].mData + (moveToOffset * asbd->mBytesPerFrame)),
+                    (const void *)((uintptr_t)dst_abl->mBuffers[i].mData + (writeOffset * asbd->mBytesPerFrame)),
+                    framesToMove * asbd->mBytesPerFrame);
+    }
 
-	if(framesToInsert) {
-		for(UInt32 i = 0; i < src_abl->mNumberBuffers; ++i)
-			memcpy((void *)((uintptr_t)dst_abl->mBuffers[i].mData + (writeOffset * asbd->mBytesPerFrame)),
-				   (const void *)((uintptr_t)src_abl->mBuffers[i].mData + (readOffset * asbd->mBytesPerFrame)),
-				   framesToInsert * asbd->mBytesPerFrame);
+    if (framesToInsert) {
+        for (UInt32 i = 0; i < src_abl->mNumberBuffers; ++i)
+            memcpy((void *)((uintptr_t)dst_abl->mBuffers[i].mData + (writeOffset * asbd->mBytesPerFrame)),
+                   (const void *)((uintptr_t)src_abl->mBuffers[i].mData + (readOffset * asbd->mBytesPerFrame)),
+                   framesToInsert * asbd->mBytesPerFrame);
 
-		self.frameLength += framesToInsert;
-	}
+        self.frameLength += framesToInsert;
+    }
 
-	return framesToInsert;
+    return framesToInsert;
 }
 
-- (AVAudioFrameCount)trimFirst:(AVAudioFrameCount)frameLength
-{
-	return [self trimAtOffset:0 frameLength:frameLength];
+- (AVAudioFrameCount)trimFirst:(AVAudioFrameCount)frameLength {
+    return [self trimAtOffset:0 frameLength:frameLength];
 }
 
-- (AVAudioFrameCount)trimLast:(AVAudioFrameCount)frameLength
-{
-	AVAudioFrameCount framesToTrim = MIN(frameLength, self.frameLength);
-	self.frameLength -= framesToTrim;
-	return framesToTrim;
+- (AVAudioFrameCount)trimLast:(AVAudioFrameCount)frameLength {
+    AVAudioFrameCount framesToTrim = MIN(frameLength, self.frameLength);
+    self.frameLength -= framesToTrim;
+    return framesToTrim;
 }
 
-- (AVAudioFrameCount)trimAtOffset:(AVAudioFrameCount)offset frameLength:(AVAudioFrameCount)frameLength
-{
-	if(offset > self.frameLength || frameLength == 0)
-		return 0;
+- (AVAudioFrameCount)trimAtOffset:(AVAudioFrameCount)offset frameLength:(AVAudioFrameCount)frameLength {
+    if (offset > self.frameLength || frameLength == 0)
+        return 0;
 
-	AVAudioFrameCount framesToTrim = MIN(frameLength, self.frameLength - offset);
+    AVAudioFrameCount framesToTrim = MIN(frameLength, self.frameLength - offset);
 
-	const AudioStreamBasicDescription *asbd = self.format.streamDescription;
-	const AudioBufferList *abl = self.audioBufferList;
+    const AudioStreamBasicDescription *asbd = self.format.streamDescription;
+    const AudioBufferList *abl = self.audioBufferList;
 
-	AVAudioFrameCount framesToMove = self.frameLength - (offset + framesToTrim);
-	if(framesToMove) {
-		AVAudioFrameCount moveFromOffset = offset + framesToTrim;
-		for(UInt32 i = 0; i < abl->mNumberBuffers; ++i)
-			memmove((void *)((uintptr_t)abl->mBuffers[i].mData + (offset * asbd->mBytesPerFrame)),
-					(const void *)((uintptr_t)abl->mBuffers[i].mData + (moveFromOffset * asbd->mBytesPerFrame)),
-					framesToMove * asbd->mBytesPerFrame);
-	}
+    AVAudioFrameCount framesToMove = self.frameLength - (offset + framesToTrim);
+    if (framesToMove) {
+        AVAudioFrameCount moveFromOffset = offset + framesToTrim;
+        for (UInt32 i = 0; i < abl->mNumberBuffers; ++i)
+            memmove((void *)((uintptr_t)abl->mBuffers[i].mData + (offset * asbd->mBytesPerFrame)),
+                    (const void *)((uintptr_t)abl->mBuffers[i].mData + (moveFromOffset * asbd->mBytesPerFrame)),
+                    framesToMove * asbd->mBytesPerFrame);
+    }
 
-	self.frameLength -= framesToTrim;
+    self.frameLength -= framesToTrim;
 
-	return framesToTrim;
+    return framesToTrim;
 }
 
-- (AVAudioFrameCount)fillRemainderWithSilence
-{
-	return [self insertSilenceAtOffset:self.frameLength frameLength:self.frameCapacity - self.frameLength];
+- (AVAudioFrameCount)fillRemainderWithSilence {
+    return [self insertSilenceAtOffset:self.frameLength frameLength:self.frameCapacity - self.frameLength];
 }
 
-- (AVAudioFrameCount)appendSilenceOfLength:(AVAudioFrameCount)frameLength
-{
-	return [self insertSilenceAtOffset:self.frameLength frameLength:frameLength];
+- (AVAudioFrameCount)appendSilenceOfLength:(AVAudioFrameCount)frameLength {
+    return [self insertSilenceAtOffset:self.frameLength frameLength:frameLength];
 }
 
-- (AVAudioFrameCount)insertSilenceAtOffset:(AVAudioFrameCount)offset frameLength:(AVAudioFrameCount)frameLength
-{
-	if(offset > self.frameLength || frameLength == 0)
-		return 0;
+- (AVAudioFrameCount)insertSilenceAtOffset:(AVAudioFrameCount)offset frameLength:(AVAudioFrameCount)frameLength {
+    if (offset > self.frameLength || frameLength == 0)
+        return 0;
 
-	AVAudioFrameCount framesToZero = MIN(self.frameCapacity - self.frameLength, frameLength);
+    AVAudioFrameCount framesToZero = MIN(self.frameCapacity - self.frameLength, frameLength);
 
-	const AudioStreamBasicDescription *asbd = self.format.streamDescription;
-	const AudioBufferList *abl = self.audioBufferList;
+    const AudioStreamBasicDescription *asbd = self.format.streamDescription;
+    const AudioBufferList *abl = self.audioBufferList;
 
-	NSAssert((asbd->mFormatFlags & kAudioFormatFlagIsFloat) || ((asbd->mFormatFlags & kAudioFormatFlagIsSignedInteger) && (asbd->mFormatFlags & kAudioFormatFlagIsPacked)), @"Inserting silence for unsigned integer or unpacked samples not supported");
+    NSAssert((asbd->mFormatFlags & kAudioFormatFlagIsFloat) ||
+                   ((asbd->mFormatFlags & kAudioFormatFlagIsSignedInteger) &&
+                    (asbd->mFormatFlags & kAudioFormatFlagIsPacked)),
+             @"Inserting silence for unsigned integer or unpacked samples not supported");
 
-	AVAudioFrameCount framesToMove = self.frameLength - offset;
-	if(framesToMove) {
-		AVAudioFrameCount moveToOffset = offset + framesToZero;
-		for(UInt32 i = 0; i < abl->mNumberBuffers; ++i)
-			memmove((void *)((uintptr_t)abl->mBuffers[i].mData + (moveToOffset * asbd->mBytesPerFrame)),
-					(const void *)((uintptr_t)abl->mBuffers[i].mData + (offset * asbd->mBytesPerFrame)),
-					framesToMove * asbd->mBytesPerFrame);
-	}
+    AVAudioFrameCount framesToMove = self.frameLength - offset;
+    if (framesToMove) {
+        AVAudioFrameCount moveToOffset = offset + framesToZero;
+        for (UInt32 i = 0; i < abl->mNumberBuffers; ++i)
+            memmove((void *)((uintptr_t)abl->mBuffers[i].mData + (moveToOffset * asbd->mBytesPerFrame)),
+                    (const void *)((uintptr_t)abl->mBuffers[i].mData + (offset * asbd->mBytesPerFrame)),
+                    framesToMove * asbd->mBytesPerFrame);
+    }
 
-	if(framesToZero) {
-		for(UInt32 i = 0; i < abl->mNumberBuffers; ++i)
-			memset((void *)((uintptr_t)abl->mBuffers[i].mData + (offset * asbd->mBytesPerFrame)),
-				   0,
-				   framesToZero * asbd->mBytesPerFrame);
+    if (framesToZero) {
+        for (UInt32 i = 0; i < abl->mNumberBuffers; ++i)
+            memset((void *)((uintptr_t)abl->mBuffers[i].mData + (offset * asbd->mBytesPerFrame)), 0,
+                   framesToZero * asbd->mBytesPerFrame);
 
-		self.frameLength += framesToZero;
-	}
+        self.frameLength += framesToZero;
+    }
 
-	return framesToZero;
+    return framesToZero;
 }
 
-- (BOOL)isEmpty
-{
-	return self.frameLength == 0;
+- (BOOL)isEmpty {
+    return self.frameLength == 0;
 }
 
-- (BOOL)isFull
-{
-	return self.frameLength == self.frameCapacity;
+- (BOOL)isFull {
+    return self.frameLength == self.frameCapacity;
 }
 
-- (BOOL)isDigitalSilence
-{
-	if(self.frameLength == 0)
-		return YES;
+- (BOOL)isDigitalSilence {
+    if (self.frameLength == 0)
+        return YES;
 
-	const AudioStreamBasicDescription *asbd = self.format.streamDescription;
-	const AudioBufferList *abl = self.audioBufferList;
+    const AudioStreamBasicDescription *asbd = self.format.streamDescription;
+    const AudioBufferList *abl = self.audioBufferList;
 
-	// Floating point
-	if(asbd->mFormatFlags & kAudioFormatFlagIsFloat) {
-		NSAssert(asbd->mBitsPerChannel == 32 || asbd->mBitsPerChannel == 64, @"Unsupported mBitsPerChannel %d for kAudioFormatFlagIsFloat", asbd->mBitsPerChannel);
-		if(asbd->mBitsPerChannel == 32) {
-			for(UInt32 i = 0; i < abl->mNumberBuffers; ++i) {
-				const float *buf = (const float *)abl->mBuffers[i].mData;
-				for(UInt32 sampleNumber = 0; i < abl->mBuffers[i].mDataByteSize / sizeof(float); ++sampleNumber) {
-					if(buf[sampleNumber] != 0)
-						return NO;
-				}
-			}
-			return YES;
-		}
-		else if(asbd->mBitsPerChannel == 64) {
-			for(UInt32 i = 0; i < abl->mNumberBuffers; ++i) {
-				const double *buf = (const double *)abl->mBuffers[i].mData;
-				for(UInt32 sampleNumber = 0; i < abl->mBuffers[i].mDataByteSize / sizeof(double); ++sampleNumber) {
-					if(buf[sampleNumber] != 0)
-						return NO;
-				}
-			}
-			return YES;
-		}
-	}
-	// Integer
-	else {
-		const UInt32 interleavedChannelCount = asbd->mFormatFlags & kAudioFormatFlagIsNonInterleaved ? 1 : asbd->mChannelsPerFrame;
-		const UInt32 bytesPerSample = asbd->mBytesPerFrame / interleavedChannelCount;
+    // Floating point
+    if (asbd->mFormatFlags & kAudioFormatFlagIsFloat) {
+        NSAssert(asbd->mBitsPerChannel == 32 || asbd->mBitsPerChannel == 64,
+                 @"Unsupported mBitsPerChannel %d for kAudioFormatFlagIsFloat", asbd->mBitsPerChannel);
+        if (asbd->mBitsPerChannel == 32) {
+            for (UInt32 i = 0; i < abl->mNumberBuffers; ++i) {
+                const float *buf = (const float *)abl->mBuffers[i].mData;
+                for (UInt32 sampleNumber = 0; i < abl->mBuffers[i].mDataByteSize / sizeof(float); ++sampleNumber) {
+                    if (buf[sampleNumber] != 0)
+                        return NO;
+                }
+            }
+            return YES;
+        } else if (asbd->mBitsPerChannel == 64) {
+            for (UInt32 i = 0; i < abl->mNumberBuffers; ++i) {
+                const double *buf = (const double *)abl->mBuffers[i].mData;
+                for (UInt32 sampleNumber = 0; i < abl->mBuffers[i].mDataByteSize / sizeof(double); ++sampleNumber) {
+                    if (buf[sampleNumber] != 0)
+                        return NO;
+                }
+            }
+            return YES;
+        }
+    }
+    // Integer
+    else {
+        const UInt32 interleavedChannelCount =
+              asbd->mFormatFlags & kAudioFormatFlagIsNonInterleaved ? 1 : asbd->mChannelsPerFrame;
+        const UInt32 bytesPerSample = asbd->mBytesPerFrame / interleavedChannelCount;
 
-		NSAssert(bytesPerSample == 1 || bytesPerSample == 2 || bytesPerSample == 3 || bytesPerSample == 4 || bytesPerSample == 8, @"Unsupported sample width %d", bytesPerSample);
+        NSAssert(bytesPerSample == 1 || bytesPerSample == 2 || bytesPerSample == 3 || bytesPerSample == 4 ||
+                       bytesPerSample == 8,
+                 @"Unsupported sample width %d", bytesPerSample);
 
-		// Integer, packed
-		if(asbd->mFormatFlags & kAudioFormatFlagIsPacked /*|| ((asbd->mBitsPerChannel / 8) * asbd->mChannelsPerFrame) == asbd->mBytesPerFrame*/) {
-			switch(bytesPerSample) {
-				case 1: {
-					const uint8_t silence = asbd->mFormatFlags & kAudioFormatFlagIsSignedInteger ? 0 : 0x80;
-					for(UInt32 i = 0; i < abl->mNumberBuffers; ++i) {
-						const uint8_t *buf = (const uint8_t *)abl->mBuffers[i].mData;
-						size_t sampleCount = abl->mBuffers[i].mDataByteSize / bytesPerSample;
-						while(sampleCount--) {
-							if(*buf != silence)
-								return NO;
-							++buf;
-						}
-					}
-					return YES;
-				}
-				case 2: {
-					const uint16_t silence = asbd->mFormatFlags & kAudioFormatFlagIsSignedInteger ? 0 : 0x8000;
-					for(UInt32 i = 0; i < abl->mNumberBuffers; ++i) {
-						const uint16_t *buf = (const uint16_t *)abl->mBuffers[i].mData;
-						size_t sampleCount = abl->mBuffers[i].mDataByteSize / bytesPerSample;
-						while(sampleCount--) {
-							if(*buf != silence)
-								return NO;
-							++buf;
-						}
-					}
-					return YES;
-				}
-				case 3: {
-					const uint32_t silence = asbd->mFormatFlags & kAudioFormatFlagIsSignedInteger ? 0 : 0x800000;
-					for(UInt32 i = 0; i < abl->mNumberBuffers; ++i) {
-						const uint8_t *buf = (const uint8_t *)abl->mBuffers[i].mData;
-						size_t sampleCount = abl->mBuffers[i].mDataByteSize / bytesPerSample;
-						while(sampleCount--) {
-							uint32_t sample = 0;
-							if(asbd->mFormatFlags & kAudioFormatFlagIsBigEndian) {
-								sample |= (*buf++ << 16) & 0xff0000;
-								sample |= (*buf++ << 8) & 0xff00;
-								sample |= *buf++ & 0xff;
-							}
-							else {
-								sample |= *buf++ & 0xff;
-								sample |= (*buf++ << 8) & 0xff00;
-								sample |= (*buf++ << 16) & 0xff0000;
-							}
-							if(sample != silence)
-								return NO;
-						}
-					}
-					return YES;
-				}
-				case 4: {
-					const uint32_t silence = asbd->mFormatFlags & kAudioFormatFlagIsSignedInteger ? 0 : 0x80000000;
-					for(UInt32 i = 0; i < abl->mNumberBuffers; ++i) {
-						const uint32_t *buf = (const uint32_t *)abl->mBuffers[i].mData;
-						size_t sampleCount = abl->mBuffers[i].mDataByteSize / bytesPerSample;
-						while(sampleCount--) {
-							if(*buf != silence)
-								return NO;
-							++buf;
-						}
-					}
-					return YES;
-				}
-				case 8: {
-					const uint64_t silence = asbd->mFormatFlags & kAudioFormatFlagIsSignedInteger ? 0 : 0x8000000000000000;
-					for(UInt32 i = 0; i < abl->mNumberBuffers; ++i) {
-						const uint64_t *buf = (const uint64_t *)abl->mBuffers[i].mData;
-						size_t sampleCount = abl->mBuffers[i].mDataByteSize / bytesPerSample;
-						while(sampleCount--) {
-							if(*buf != silence)
-								return NO;
-							++buf;
-						}
-					}
-					return YES;
-				}
-			}
-		}
-		// Integer, unpacked
-		else {
-			const size_t shift = (bytesPerSample * 8) - asbd->mBitsPerChannel;
-			switch(bytesPerSample) {
-				case 1: {
-					const uint8_t silence = asbd->mFormatFlags & kAudioFormatFlagIsSignedInteger ? 0 : (uint8_t)(1 << ((asbd->mBitsPerChannel - 1) + (asbd->mFormatFlags & kAudioFormatFlagIsAlignedHigh ? shift : 0)));
-					for(UInt32 i = 0; i < abl->mNumberBuffers; ++i) {
-						const uint8_t *buf = (const uint8_t *)abl->mBuffers[i].mData;
-						size_t sampleCount = abl->mBuffers[i].mDataByteSize / bytesPerSample;
-						while(sampleCount--) {
-							if(*buf != silence)
-								return NO;
-							++buf;
-						}
-					}
-					return YES;
-				}
-				case 2: {
-					const uint16_t silence = asbd->mFormatFlags & kAudioFormatFlagIsSignedInteger ? 0 : (uint16_t)(1 << ((asbd->mBitsPerChannel - 1) + (asbd->mFormatFlags & kAudioFormatFlagIsAlignedHigh ? shift : 0)));
-					for(UInt32 i = 0; i < abl->mNumberBuffers; ++i) {
-						const uint16_t *buf = (const uint16_t *)abl->mBuffers[i].mData;
-						size_t sampleCount = abl->mBuffers[i].mDataByteSize / bytesPerSample;
-						while(sampleCount--) {
-							if(*buf != silence)
-								return NO;
-							++buf;
-						}
-					}
-					return YES;
-				}
-				case 3: {
-					const uint32_t silence = asbd->mFormatFlags & kAudioFormatFlagIsSignedInteger ? 0 : (uint32_t)(1 << ((asbd->mBitsPerChannel - 1) + (asbd->mFormatFlags & kAudioFormatFlagIsAlignedHigh ? shift : 0)));
-					for(UInt32 i = 0; i < abl->mNumberBuffers; ++i) {
-						const uint8_t *buf = (const uint8_t *)abl->mBuffers[i].mData;
-						size_t sampleCount = abl->mBuffers[i].mDataByteSize / bytesPerSample;
-						while(sampleCount--) {
-							uint32_t sample = 0;
-							if(asbd->mFormatFlags & kAudioFormatFlagIsBigEndian) {
-								sample |= (*buf++ << 16) & 0xff0000;
-								sample |= (*buf++ << 8) & 0xff00;
-								sample |= *buf++ & 0xff;
-							}
-							else {
-								sample |= *buf++ & 0xff;
-								sample |= (*buf++ << 8) & 0xff00;
-								sample |= (*buf++ << 16) & 0xff0000;
-							}
-							if(sample != silence)
-								return NO;
-						}
-					}
-					return YES;
-				}
-				case 4: {
-					const uint32_t silence = asbd->mFormatFlags & kAudioFormatFlagIsSignedInteger ? 0 : (uint32_t)(1 << ((asbd->mBitsPerChannel - 1) + (asbd->mFormatFlags & kAudioFormatFlagIsAlignedHigh ? shift : 0)));
-					for(UInt32 i = 0; i < abl->mNumberBuffers; ++i) {
-						const uint32_t *buf = (const uint32_t *)abl->mBuffers[i].mData;
-						size_t sampleCount = abl->mBuffers[i].mDataByteSize / bytesPerSample;
-						while(sampleCount--) {
-							if(*buf != silence)
-								return NO;
-							++buf;
-						}
-					}
-					return YES;
-				}
-				case 8: {
-					const uint64_t silence = asbd->mFormatFlags & kAudioFormatFlagIsSignedInteger ? 0 : (uint64_t)(1 << ((asbd->mBitsPerChannel - 1) + (asbd->mFormatFlags & kAudioFormatFlagIsAlignedHigh ? shift : 0)));
-					for(UInt32 i = 0; i < abl->mNumberBuffers; ++i) {
-						const uint64_t *buf = (const uint64_t *)abl->mBuffers[i].mData;
-						size_t sampleCount = abl->mBuffers[i].mDataByteSize / bytesPerSample;
-						while(sampleCount--) {
-							if(*buf != silence)
-								return NO;
-							++buf;
-						}
-					}
-					return YES;
-				}
-			}
-		}
-	}
+        // Integer, packed
+        if(asbd->mFormatFlags & kAudioFormatFlagIsPacked /*|| ((asbd->mBitsPerChannel / 8) * asbd->mChannelsPerFrame) == asbd->mBytesPerFrame*/) {
+            switch (bytesPerSample) {
+            case 1: {
+                const uint8_t silence = asbd->mFormatFlags & kAudioFormatFlagIsSignedInteger ? 0 : 0x80;
+                for (UInt32 i = 0; i < abl->mNumberBuffers; ++i) {
+                    const uint8_t *buf = (const uint8_t *)abl->mBuffers[i].mData;
+                    size_t sampleCount = abl->mBuffers[i].mDataByteSize / bytesPerSample;
+                    while (sampleCount--) {
+                        if (*buf != silence)
+                            return NO;
+                        ++buf;
+                    }
+                }
+                return YES;
+            }
+            case 2: {
+                const uint16_t silence = asbd->mFormatFlags & kAudioFormatFlagIsSignedInteger ? 0 : 0x8000;
+                for (UInt32 i = 0; i < abl->mNumberBuffers; ++i) {
+                    const uint16_t *buf = (const uint16_t *)abl->mBuffers[i].mData;
+                    size_t sampleCount = abl->mBuffers[i].mDataByteSize / bytesPerSample;
+                    while (sampleCount--) {
+                        if (*buf != silence)
+                            return NO;
+                        ++buf;
+                    }
+                }
+                return YES;
+            }
+            case 3: {
+                const uint32_t silence = asbd->mFormatFlags & kAudioFormatFlagIsSignedInteger ? 0 : 0x800000;
+                for (UInt32 i = 0; i < abl->mNumberBuffers; ++i) {
+                    const uint8_t *buf = (const uint8_t *)abl->mBuffers[i].mData;
+                    size_t sampleCount = abl->mBuffers[i].mDataByteSize / bytesPerSample;
+                    while (sampleCount--) {
+                        uint32_t sample = 0;
+                        if (asbd->mFormatFlags & kAudioFormatFlagIsBigEndian) {
+                            sample |= (*buf++ << 16) & 0xff0000;
+                            sample |= (*buf++ << 8) & 0xff00;
+                            sample |= *buf++ & 0xff;
+                        } else {
+                            sample |= *buf++ & 0xff;
+                            sample |= (*buf++ << 8) & 0xff00;
+                            sample |= (*buf++ << 16) & 0xff0000;
+                        }
+                        if (sample != silence)
+                            return NO;
+                    }
+                }
+                return YES;
+            }
+            case 4: {
+                const uint32_t silence = asbd->mFormatFlags & kAudioFormatFlagIsSignedInteger ? 0 : 0x80000000;
+                for (UInt32 i = 0; i < abl->mNumberBuffers; ++i) {
+                    const uint32_t *buf = (const uint32_t *)abl->mBuffers[i].mData;
+                    size_t sampleCount = abl->mBuffers[i].mDataByteSize / bytesPerSample;
+                    while (sampleCount--) {
+                        if (*buf != silence)
+                            return NO;
+                        ++buf;
+                    }
+                }
+                return YES;
+            }
+            case 8: {
+                const uint64_t silence = asbd->mFormatFlags & kAudioFormatFlagIsSignedInteger ? 0 : 0x8000000000000000;
+                for (UInt32 i = 0; i < abl->mNumberBuffers; ++i) {
+                    const uint64_t *buf = (const uint64_t *)abl->mBuffers[i].mData;
+                    size_t sampleCount = abl->mBuffers[i].mDataByteSize / bytesPerSample;
+                    while (sampleCount--) {
+                        if (*buf != silence)
+                            return NO;
+                        ++buf;
+                    }
+                }
+                return YES;
+            }
+            }
+        }
+        // Integer, unpacked
+        else {
+            const size_t shift = (bytesPerSample * 8) - asbd->mBitsPerChannel;
+            switch (bytesPerSample) {
+            case 1: {
+                const uint8_t silence =
+                      asbd->mFormatFlags & kAudioFormatFlagIsSignedInteger
+                            ? 0
+                            : (uint8_t)(1 << ((asbd->mBitsPerChannel - 1) +
+                                              (asbd->mFormatFlags & kAudioFormatFlagIsAlignedHigh ? shift : 0)));
+                for (UInt32 i = 0; i < abl->mNumberBuffers; ++i) {
+                    const uint8_t *buf = (const uint8_t *)abl->mBuffers[i].mData;
+                    size_t sampleCount = abl->mBuffers[i].mDataByteSize / bytesPerSample;
+                    while (sampleCount--) {
+                        if (*buf != silence)
+                            return NO;
+                        ++buf;
+                    }
+                }
+                return YES;
+            }
+            case 2: {
+                const uint16_t silence =
+                      asbd->mFormatFlags & kAudioFormatFlagIsSignedInteger
+                            ? 0
+                            : (uint16_t)(1 << ((asbd->mBitsPerChannel - 1) +
+                                               (asbd->mFormatFlags & kAudioFormatFlagIsAlignedHigh ? shift : 0)));
+                for (UInt32 i = 0; i < abl->mNumberBuffers; ++i) {
+                    const uint16_t *buf = (const uint16_t *)abl->mBuffers[i].mData;
+                    size_t sampleCount = abl->mBuffers[i].mDataByteSize / bytesPerSample;
+                    while (sampleCount--) {
+                        if (*buf != silence)
+                            return NO;
+                        ++buf;
+                    }
+                }
+                return YES;
+            }
+            case 3: {
+                const uint32_t silence =
+                      asbd->mFormatFlags & kAudioFormatFlagIsSignedInteger
+                            ? 0
+                            : (uint32_t)(1 << ((asbd->mBitsPerChannel - 1) +
+                                               (asbd->mFormatFlags & kAudioFormatFlagIsAlignedHigh ? shift : 0)));
+                for (UInt32 i = 0; i < abl->mNumberBuffers; ++i) {
+                    const uint8_t *buf = (const uint8_t *)abl->mBuffers[i].mData;
+                    size_t sampleCount = abl->mBuffers[i].mDataByteSize / bytesPerSample;
+                    while (sampleCount--) {
+                        uint32_t sample = 0;
+                        if (asbd->mFormatFlags & kAudioFormatFlagIsBigEndian) {
+                            sample |= (*buf++ << 16) & 0xff0000;
+                            sample |= (*buf++ << 8) & 0xff00;
+                            sample |= *buf++ & 0xff;
+                        } else {
+                            sample |= *buf++ & 0xff;
+                            sample |= (*buf++ << 8) & 0xff00;
+                            sample |= (*buf++ << 16) & 0xff0000;
+                        }
+                        if (sample != silence)
+                            return NO;
+                    }
+                }
+                return YES;
+            }
+            case 4: {
+                const uint32_t silence =
+                      asbd->mFormatFlags & kAudioFormatFlagIsSignedInteger
+                            ? 0
+                            : (uint32_t)(1 << ((asbd->mBitsPerChannel - 1) +
+                                               (asbd->mFormatFlags & kAudioFormatFlagIsAlignedHigh ? shift : 0)));
+                for (UInt32 i = 0; i < abl->mNumberBuffers; ++i) {
+                    const uint32_t *buf = (const uint32_t *)abl->mBuffers[i].mData;
+                    size_t sampleCount = abl->mBuffers[i].mDataByteSize / bytesPerSample;
+                    while (sampleCount--) {
+                        if (*buf != silence)
+                            return NO;
+                        ++buf;
+                    }
+                }
+                return YES;
+            }
+            case 8: {
+                const uint64_t silence =
+                      asbd->mFormatFlags & kAudioFormatFlagIsSignedInteger
+                            ? 0
+                            : (uint64_t)(1 << ((asbd->mBitsPerChannel - 1) +
+                                               (asbd->mFormatFlags & kAudioFormatFlagIsAlignedHigh ? shift : 0)));
+                for (UInt32 i = 0; i < abl->mNumberBuffers; ++i) {
+                    const uint64_t *buf = (const uint64_t *)abl->mBuffers[i].mData;
+                    size_t sampleCount = abl->mBuffers[i].mDataByteSize / bytesPerSample;
+                    while (sampleCount--) {
+                        if (*buf != silence)
+                            return NO;
+                        ++buf;
+                    }
+                }
+                return YES;
+            }
+            }
+        }
+    }
 
-	return NO;
+    return NO;
 }
 
 @end
-

--- a/Sources/AVFAudioExtensions/AVAudioPCMBuffer+SFBBufferUtilities.m
+++ b/Sources/AVFAudioExtensions/AVAudioPCMBuffer+SFBBufferUtilities.m
@@ -215,7 +215,7 @@
                  @"Unsupported sample width %d", bytesPerSample);
 
         // Integer, packed
-        if(asbd->mFormatFlags & kAudioFormatFlagIsPacked /*|| ((asbd->mBitsPerChannel / 8) * asbd->mChannelsPerFrame) == asbd->mBytesPerFrame*/) {
+        if (asbd->mFormatFlags & kAudioFormatFlagIsPacked) {
             switch (bytesPerSample) {
             case 1: {
                 const uint8_t silence = asbd->mFormatFlags & kAudioFormatFlagIsSignedInteger ? 0 : 0x80;

--- a/Sources/AVFAudioExtensions/include/AVFAudioExtensions/AVAudioChannelLayout+SFBChannelLabels.h
+++ b/Sources/AVFAudioExtensions/include/AVFAudioExtensions/AVAudioChannelLayout+SFBChannelLabels.h
@@ -17,8 +17,10 @@ NS_ASSUME_NONNULL_BEGIN
 /// Returns an initialized `AVAudioChannelLayout` object with the specified channel labels or `nil` on failure
 /// - parameter channelLabels: An array of channel labels
 /// - parameter count: The number of channel labels
-+ (nullable instancetype)layoutWithChannelLabels:(const AudioChannelLabel *)channelLabels count:(AVAudioChannelCount)count;
-/// Returns an initialized `AVAudioChannelLayout` object according to the specified channel label string or `nil` on failure
++ (nullable instancetype)layoutWithChannelLabels:(const AudioChannelLabel *)channelLabels
+                                           count:(AVAudioChannelCount)count;
+/// Returns an initialized `AVAudioChannelLayout` object according to the specified channel label string or `nil` on
+/// failure
 /// - parameter channelLabelString: A string containing the channel labels
 + (nullable instancetype)layoutWithChannelLabelString:(NSString *)channelLabelString;
 /// Returns an initialized `AVAudioChannelLayout` object with the specified channel labels or `nil` on failure
@@ -31,13 +33,15 @@ NS_ASSUME_NONNULL_BEGIN
 /// Returns an initialized `AVAudioChannelLayout` object with the specified channel labels or `nil` on failure
 /// - parameter channelLabels: An array of channel labels
 /// - parameter count: The number of channel labels
-- (nullable instancetype)initWithChannelLabels:(const AudioChannelLabel *)channelLabels count:(AVAudioChannelCount)count;
-/// Returns an initialized `AVAudioChannelLayout` object according to the specified channel label string or `nil` on failure
+- (nullable instancetype)initWithChannelLabels:(const AudioChannelLabel *)channelLabels
+                                         count:(AVAudioChannelCount)count;
+/// Returns an initialized `AVAudioChannelLayout` object according to the specified channel label string or `nil` on
+/// failure
 /// - note: The string comparisons are case-insensitive
 ///
 /// The following channel label strings are recognized:
 ///
-///String | Meaning
+/// String | Meaning
 /// --- | ---
 /// L | `kAudioChannelLabel_Left`
 /// R | `kAudioChannelLabel_Right`
@@ -64,7 +68,8 @@ NS_ASSUME_NONNULL_BEGIN
 ///
 /// All other strings are mapped to `kAudioChannelLabel_Unknown`
 /// - parameter channelLabelString: A string containing the channel labels
-- (nullable instancetype)initWithChannelLabelString:(NSString *)channelLabelString NS_SWIFT_NAME(init(channelLabelString:));
+- (nullable instancetype)initWithChannelLabelString:(NSString *)channelLabelString
+      NS_SWIFT_NAME(init(channelLabelString:));
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sources/AVFAudioExtensions/include/AVFAudioExtensions/AVAudioChannelLayout+SFBLayoutNames.h
+++ b/Sources/AVFAudioExtensions/include/AVFAudioExtensions/AVAudioChannelLayout+SFBLayoutNames.h
@@ -15,11 +15,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// Returns the name of the channel layout.
 /// - note: This is the value returned by `kAudioFormatProperty_ChannelLayoutName`
-@property (nonatomic, readonly) NSString * layoutName;
+@property(nonatomic, readonly) NSString *layoutName;
 
 /// Returns the name of the channel layout without channel labels.
 /// - note: This is the value returned by `kAudioFormatProperty_ChannelLayoutSimpleName`
-@property (nonatomic, readonly) NSString * layoutSimpleName;
+@property(nonatomic, readonly) NSString *layoutSimpleName;
 
 @end
 

--- a/Sources/AVFAudioExtensions/include/AVFAudioExtensions/AVAudioFormat+SFBFormatName.h
+++ b/Sources/AVFAudioExtensions/include/AVFAudioExtensions/AVAudioFormat+SFBFormatName.h
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// Returns the name of the audio format.
 /// - note: This is the value returned by `kAudioFormatProperty_FormatName`
-@property (nonatomic, readonly) NSString * formatName;
+@property(nonatomic, readonly) NSString *formatName;
 
 @end
 

--- a/Sources/AVFAudioExtensions/include/AVFAudioExtensions/AVAudioPCMBuffer+SFBBufferUtilities.h
+++ b/Sources/AVFAudioExtensions/include/AVFAudioExtensions/AVAudioPCMBuffer+SFBBufferUtilities.h
@@ -21,14 +21,17 @@ NS_ASSUME_NONNULL_BEGIN
 /// - parameter buffer: A buffer of audio data
 /// - parameter offset: The desired starting offset in `buffer`
 /// - returns: The number of frames prepended
-- (AVAudioFrameCount)prependFromBuffer:(AVAudioPCMBuffer *)buffer readingFromOffset:(AVAudioFrameCount)offset NS_SWIFT_NAME(prepend(_:from:));
+- (AVAudioFrameCount)prependFromBuffer:(AVAudioPCMBuffer *)buffer
+                     readingFromOffset:(AVAudioFrameCount)offset NS_SWIFT_NAME(prepend(_:from:));
 /// Prepends at most `frameLength` frames from `buffer` starting at `offset` to `self`
 /// - important: The format of `buffer` must match the format of `self`
 /// - parameter buffer: A buffer of audio data
 /// - parameter offset: The desired starting offset in `buffer`
 /// - parameter frameLength: The desired number of frames
 /// - returns: The number of frames prepended
-- (AVAudioFrameCount)prependFromBuffer:(AVAudioPCMBuffer *)buffer readingFromOffset:(AVAudioFrameCount)offset frameLength:(AVAudioFrameCount)frameLength NS_SWIFT_NAME(prepend(_:from:length:));
+- (AVAudioFrameCount)prependFromBuffer:(AVAudioPCMBuffer *)buffer
+                     readingFromOffset:(AVAudioFrameCount)offset
+                           frameLength:(AVAudioFrameCount)frameLength NS_SWIFT_NAME(prepend(_:from:length:));
 
 /// Appends the contents of `buffer` to `self`
 /// - important: The format of `buffer` must match the format of `self`
@@ -40,21 +43,25 @@ NS_ASSUME_NONNULL_BEGIN
 /// - parameter buffer: A buffer of audio data
 /// - parameter offset: The desired starting offset in `buffer`
 /// - returns: The number of frames appended
-- (AVAudioFrameCount)appendFromBuffer:(AVAudioPCMBuffer *)buffer readingFromOffset:(AVAudioFrameCount)offset NS_SWIFT_NAME(append(_:from:));
+- (AVAudioFrameCount)appendFromBuffer:(AVAudioPCMBuffer *)buffer
+                    readingFromOffset:(AVAudioFrameCount)offset NS_SWIFT_NAME(append(_:from:));
 /// Appends at most `frameLength` frames from `buffer` starting at `offset` to `self`
 /// - important: The format of `buffer` must match the format of `self`
 /// - parameter buffer: A buffer of audio data
 /// - parameter offset: The desired starting offset in `buffer`
 /// - parameter frameLength: The desired number of frames
 /// - returns: The number of frames appended
-- (AVAudioFrameCount)appendFromBuffer:(AVAudioPCMBuffer *)buffer readingFromOffset:(AVAudioFrameCount)offset frameLength:(AVAudioFrameCount)frameLength NS_SWIFT_NAME(append(_:from:length:));
+- (AVAudioFrameCount)appendFromBuffer:(AVAudioPCMBuffer *)buffer
+                    readingFromOffset:(AVAudioFrameCount)offset
+                          frameLength:(AVAudioFrameCount)frameLength NS_SWIFT_NAME(append(_:from:length:));
 
 /// Inserts the contents of `buffer` in `self` starting at `offset`
 /// - important: The format of `buffer` must match the format of `self`
 /// - parameter buffer: A buffer of audio data
 /// - parameter offset: The desired starting offset in `self`
 /// - returns: The number of frames inserted
-- (AVAudioFrameCount)insertContentsOfBuffer:(AVAudioPCMBuffer *)buffer atOffset:(AVAudioFrameCount)offset NS_SWIFT_NAME(insert(_:at:));
+- (AVAudioFrameCount)insertContentsOfBuffer:(AVAudioPCMBuffer *)buffer
+                                   atOffset:(AVAudioFrameCount)offset NS_SWIFT_NAME(insert(_:at:));
 
 /// Inserts at most `readLength` frames from `buffer` starting at `readOffset` to `self` starting at `writeOffset`
 /// - important: The format of `buffer` must match the format of `self`
@@ -63,7 +70,10 @@ NS_ASSUME_NONNULL_BEGIN
 /// - parameter frameLength: The desired number of frames
 /// - parameter writeOffset: The desired starting offset in `self`
 /// - returns: The number of frames inserted
-- (AVAudioFrameCount)insertFromBuffer:(AVAudioPCMBuffer *)buffer readingFromOffset:(AVAudioFrameCount)readOffset frameLength:(AVAudioFrameCount)frameLength atOffset:(AVAudioFrameCount)writeOffset NS_SWIFT_NAME(insert(_:from:length:at:));
+- (AVAudioFrameCount)insertFromBuffer:(AVAudioPCMBuffer *)buffer
+                    readingFromOffset:(AVAudioFrameCount)readOffset
+                          frameLength:(AVAudioFrameCount)frameLength
+                             atOffset:(AVAudioFrameCount)writeOffset NS_SWIFT_NAME(insert(_:from:length:at:));
 
 /// Deletes at most the first `frameLength` frames from `self`
 /// - parameter frameLength: The desired number of frames
@@ -77,7 +87,8 @@ NS_ASSUME_NONNULL_BEGIN
 /// - parameter offset: The desired starting offset
 /// - parameter frameLength: The desired number of frames
 /// - returns: The number of frames deleted
-- (AVAudioFrameCount)trimAtOffset:(AVAudioFrameCount)offset frameLength:(AVAudioFrameCount)frameLength NS_SWIFT_NAME(trim(at:length:));
+- (AVAudioFrameCount)trimAtOffset:(AVAudioFrameCount)offset
+                      frameLength:(AVAudioFrameCount)frameLength NS_SWIFT_NAME(trim(at:length:));
 
 /// Fills the remainder of `self` with silence
 /// - returns: The number of frames of silence appended
@@ -90,7 +101,8 @@ NS_ASSUME_NONNULL_BEGIN
 /// - parameter offset: The desired starting offset
 /// - parameter frameLength: The desired number of frames
 /// - returns: The number of frames of silence inserted
-- (AVAudioFrameCount)insertSilenceAtOffset:(AVAudioFrameCount)offset frameLength:(AVAudioFrameCount)frameLength NS_SWIFT_NAME(silence(at:length:));
+- (AVAudioFrameCount)insertSilenceAtOffset:(AVAudioFrameCount)offset
+                               frameLength:(AVAudioFrameCount)frameLength NS_SWIFT_NAME(silence(at:length:));
 
 /// Returns `YES` if `self.frameLength == 0`
 - (BOOL)isEmpty;

--- a/Tests/AVFAudioExtensionsTests/AVFAudioExtensionsTests.swift
+++ b/Tests/AVFAudioExtensionsTests/AVFAudioExtensionsTests.swift
@@ -10,31 +10,31 @@ import AVFAudio
 @testable import AVFAudioExtensions
 
 final class AVFAudioExtensionsTests: XCTestCase {
-	func testChannelLabels() {
-		let labels: [AudioChannelLabel] = [kAudioChannelLabel_Left, kAudioChannelLabel_Right]
-		labels.withUnsafeBufferPointer {
-			let layout = AVAudioChannelLayout(channelLabels: $0.baseAddress!, count: AVAudioChannelCount($0.count))
-			XCTAssertNotNil(layout)
-			XCTAssert(layout!.channelCount == 2)
-		}
-	}
+    func testChannelLabels() {
+        let labels: [AudioChannelLabel] = [kAudioChannelLabel_Left, kAudioChannelLabel_Right]
+        labels.withUnsafeBufferPointer {
+            let layout = AVAudioChannelLayout(channelLabels: $0.baseAddress!, count: AVAudioChannelCount($0.count))
+            XCTAssertNotNil(layout)
+            XCTAssert(layout!.channelCount == 2)
+        }
+    }
 
-	func testChannelLabelString() {
-		let layout = AVAudioChannelLayout(channelLabelString: "L R")
-		XCTAssertNotNil(layout)
-		XCTAssert(layout!.channelCount == 2)
-	}
+    func testChannelLabelString() {
+        let layout = AVAudioChannelLayout(channelLabelString: "L R")
+        XCTAssertNotNil(layout)
+        XCTAssert(layout!.channelCount == 2)
+    }
 
-	func testChannelLayoutNames() {
-		let layout = AVAudioChannelLayout(layoutTag: kAudioChannelLayoutTag_Stereo)
-		XCTAssertNotNil(layout)
-		XCTAssertGreaterThan(layout!.layoutName.count, 0)
-		XCTAssertGreaterThan(layout!.layoutSimpleName.count, 0)
-	}
+    func testChannelLayoutNames() {
+        let layout = AVAudioChannelLayout(layoutTag: kAudioChannelLayoutTag_Stereo)
+        XCTAssertNotNil(layout)
+        XCTAssertGreaterThan(layout!.layoutName.count, 0)
+        XCTAssertGreaterThan(layout!.layoutSimpleName.count, 0)
+    }
 
-	func testFormatName() {
-		let format = AVAudioFormat(standardFormatWithSampleRate: 44100, channels: 2)
-		XCTAssertNotNil(format)
-		XCTAssertGreaterThan(format!.formatName.count, 0)
-	}
+    func testFormatName() {
+        let format = AVAudioFormat(standardFormatWithSampleRate: 44100, channels: 2)
+        XCTAssertNotNil(format)
+        XCTAssertGreaterThan(format!.formatName.count, 0)
+    }
 }


### PR DESCRIPTION
## Pull request overview

This pull request adds a `.clang-format` configuration file and reformats all Objective-C and Swift source files to conform to the LLVM-based style with project-specific settings (4-space indentation, 120-character line limit, and custom include ordering).

**Changes:**
- Added `.clang-format` configuration file with LLVM-based style settings
- Reformatted all source files: converted tabs to spaces, adjusted bracing style, split long lines, and normalized whitespace
- Updated Swift test file indentation from tabs to 4 spaces