### PR TITLE
Update links for new directory structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ Add a package dependency to https://github.com/sbooth/AVFAudioExtensions in Xcod
 
 | Extended Class | Description |
 | --- | --- |
-| [AVAudioChannelLayout](Sources/AVFAudioExtensions/include/AVAudioChannelLayout+SFBChannelLabels.h) | Functions for building channel layouts from channel labels |
-| [AVAudioFormat](Sources/AVFAudioExtensions/include/AVAudioFormat+SFBFormatTransformation.h) | Format transformations |
-| [AVAudioPCMBuffer](Sources/AVFAudioExtensions/include/AVAudioPCMBuffer+SFBBufferUtilities.h) | Functions for buffer manipulation |
+| [AVAudioChannelLayout](Sources/AVFAudioExtensions/include/AVFAudioExtensions/AVAudioChannelLayout+SFBChannelLabels.h) | Functions for building channel layouts from channel labels |
+| [AVAudioFormat](Sources/AVFAudioExtensions/include/AVFAudioExtensions/AVAudioFormat+SFBFormatTransformation.h) | Format transformations |
+| [AVAudioPCMBuffer](Sources/AVFAudioExtensions/include/AVFAudioExtensions/AVAudioPCMBuffer+SFBBufferUtilities.h) | Functions for buffer manipulation |
 
 ## License
 


### PR DESCRIPTION
## Pull request overview

This PR updates documentation links in the README to reflect a reorganized directory structure where header files have been moved into a nested `AVFAudioExtensions` subdirectory within the include folder.

**Changes:**
- Updated three header file paths in the README table to include the new `AVFAudioExtensions` subdirectory in the include path