### PR TITLE
Fix infinite loop in AVAudioPCMBuffer zero-sample verification

### DIFF
--- a/Sources/AVFAudioExtensions/AVAudioPCMBuffer+SFBBufferUtilities.m
+++ b/Sources/AVFAudioExtensions/AVAudioPCMBuffer+SFBBufferUtilities.m
@@ -187,7 +187,7 @@
         if (asbd->mBitsPerChannel == 32) {
             for (UInt32 i = 0; i < abl->mNumberBuffers; ++i) {
                 const float *buf = (const float *)abl->mBuffers[i].mData;
-                for (UInt32 sampleNumber = 0; i < abl->mBuffers[i].mDataByteSize / sizeof(float); ++sampleNumber) {
+                for (UInt32 sampleNumber = 0; sampleNumber < abl->mBuffers[i].mDataByteSize / sizeof(float); ++sampleNumber) {
                     if (buf[sampleNumber] != 0)
                         return NO;
                 }
@@ -196,7 +196,7 @@
         } else if (asbd->mBitsPerChannel == 64) {
             for (UInt32 i = 0; i < abl->mNumberBuffers; ++i) {
                 const double *buf = (const double *)abl->mBuffers[i].mData;
-                for (UInt32 sampleNumber = 0; i < abl->mBuffers[i].mDataByteSize / sizeof(double); ++sampleNumber) {
+                for (UInt32 sampleNumber = 0; sampleNumber < abl->mBuffers[i].mDataByteSize / sizeof(double); ++sampleNumber) {
                     if (buf[sampleNumber] != 0)
                         return NO;
                 }


### PR DESCRIPTION
## Pull request overview

This PR fixes a critical bug that caused infinite loops in the `isDigitalSilence` method when checking audio buffers for digital silence. The bug was caused by using the wrong loop variable in the loop condition.

**Changes:**
- Fixed infinite loop in 32-bit float sample verification by correcting loop condition variable
- Fixed infinite loop in 64-bit double sample verification by correcting loop condition variable