### PR TITLE
Reformat braces and remove return after else

### DIFF
--- a/Sources/AVFAudioExtensions/AVAudioFormat+SFBFormatTransformation.m
+++ b/Sources/AVFAudioExtensions/AVAudioFormat+SFBFormatTransformation.m
@@ -44,11 +44,10 @@
 - (nullable AVAudioFormat *)standardEquivalent {
     if (self.isStandard)
         return self;
-    else if (self.channelLayout)
+    if (self.channelLayout)
         return [[AVAudioFormat alloc] initStandardFormatWithSampleRate:self.sampleRate
                                                          channelLayout:self.channelLayout];
-    else
-        return [[AVAudioFormat alloc] initStandardFormatWithSampleRate:self.sampleRate channels:self.channelCount];
+    return [[AVAudioFormat alloc] initStandardFormatWithSampleRate:self.sampleRate channels:self.channelCount];
 }
 
 - (nullable AVAudioFormat *)transformedToCommonFormat:(AVAudioCommonFormat)commonFormat interleaved:(BOOL)interleaved {
@@ -57,11 +56,10 @@
                                                 sampleRate:self.sampleRate
                                                interleaved:interleaved
                                              channelLayout:self.channelLayout];
-    else
-        return [[AVAudioFormat alloc] initWithCommonFormat:commonFormat
-                                                sampleRate:self.sampleRate
-                                                  channels:self.channelCount
-                                               interleaved:interleaved];
+    return [[AVAudioFormat alloc] initWithCommonFormat:commonFormat
+                                            sampleRate:self.sampleRate
+                                              channels:self.channelCount
+                                           interleaved:interleaved];
 }
 
 @end

--- a/Sources/AVFAudioExtensions/AVAudioPCMBuffer+SFBBufferUtilities.m
+++ b/Sources/AVFAudioExtensions/AVAudioPCMBuffer+SFBBufferUtilities.m
@@ -180,8 +180,8 @@
     const AudioStreamBasicDescription *asbd = self.format.streamDescription;
     const AudioBufferList *abl = self.audioBufferList;
 
-    // Floating point
     if (asbd->mFormatFlags & kAudioFormatFlagIsFloat) {
+        // Floating point
         NSAssert(asbd->mBitsPerChannel == 32 || asbd->mBitsPerChannel == 64,
                  @"Unsupported mBitsPerChannel %d for kAudioFormatFlagIsFloat", asbd->mBitsPerChannel);
         if (asbd->mBitsPerChannel == 32) {
@@ -193,7 +193,8 @@
                 }
             }
             return YES;
-        } else if (asbd->mBitsPerChannel == 64) {
+        }
+        if (asbd->mBitsPerChannel == 64) {
             for (UInt32 i = 0; i < abl->mNumberBuffers; ++i) {
                 const double *buf = (const double *)abl->mBuffers[i].mData;
                 for (UInt32 sampleNumber = 0; i < abl->mBuffers[i].mDataByteSize / sizeof(double); ++sampleNumber) {
@@ -203,9 +204,8 @@
             }
             return YES;
         }
-    }
-    // Integer
-    else {
+    } else {
+        // Integer
         const UInt32 interleavedChannelCount =
               asbd->mFormatFlags & kAudioFormatFlagIsNonInterleaved ? 1 : asbd->mChannelsPerFrame;
         const UInt32 bytesPerSample = asbd->mBytesPerFrame / interleavedChannelCount;
@@ -292,9 +292,8 @@
                 return YES;
             }
             }
-        }
-        // Integer, unpacked
-        else {
+        } else {
+            // Integer, unpacked
             const size_t shift = (bytesPerSample * 8) - asbd->mBitsPerChannel;
             switch (bytesPerSample) {
             case 1: {


### PR DESCRIPTION
## Pull request overview

This PR improves code formatting and style by reformatting brace placement and removing unnecessary else clauses after early returns.

**Changes:**
- Reformatted braces to use `} else {` style instead of else on a new line
- Removed unnecessary `else` and `else if` statements that follow return statements
- Moved inline comments inside their associated code blocks for better clarity