### PR TITLE
Add `ObjCBlockIndentWidth` to .clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -7,6 +7,8 @@ UseTab: Never
 
 ColumnLimit: 120
 
+ObjCBlockIndentWidth: 4
+
 IncludeBlocks: Regroup
 IncludeCategories:
   - Regex: '^".*"$'

--- a/Sources/AVFAudioExtensions/AVAudioChannelLayout+SFBChannelLabels.m
+++ b/Sources/AVFAudioExtensions/AVAudioChannelLayout+SFBChannelLabels.m
@@ -32,33 +32,33 @@ static AudioChannelLabel ChannelLabelForString(NSString *s) {
     static NSDictionary *labels = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-      labels = @{
-          @"l" : @(kAudioChannelLabel_Left),
-          @"r" : @(kAudioChannelLabel_Right),
-          @"c" : @(kAudioChannelLabel_Center),
-          @"lfe" : @(kAudioChannelLabel_LFEScreen),
-          @"ls" : @(kAudioChannelLabel_LeftSurround),
-          @"rs" : @(kAudioChannelLabel_RightSurround),
-          @"lc" : @(kAudioChannelLabel_LeftCenter),
-          @"rc" : @(kAudioChannelLabel_RightCenter),
-          @"cs" : @(kAudioChannelLabel_CenterSurround),
-          @"lsd" : @(kAudioChannelLabel_LeftSurroundDirect),
-          @"rsd" : @(kAudioChannelLabel_RightSurroundDirect),
-          @"tcs" : @(kAudioChannelLabel_TopCenterSurround),
-          @"vhl" : @(kAudioChannelLabel_VerticalHeightLeft),
-          @"vhc" : @(kAudioChannelLabel_VerticalHeightCenter),
-          @"vhr" : @(kAudioChannelLabel_VerticalHeightRight),
+        labels = @{
+            @"l" : @(kAudioChannelLabel_Left),
+            @"r" : @(kAudioChannelLabel_Right),
+            @"c" : @(kAudioChannelLabel_Center),
+            @"lfe" : @(kAudioChannelLabel_LFEScreen),
+            @"ls" : @(kAudioChannelLabel_LeftSurround),
+            @"rs" : @(kAudioChannelLabel_RightSurround),
+            @"lc" : @(kAudioChannelLabel_LeftCenter),
+            @"rc" : @(kAudioChannelLabel_RightCenter),
+            @"cs" : @(kAudioChannelLabel_CenterSurround),
+            @"lsd" : @(kAudioChannelLabel_LeftSurroundDirect),
+            @"rsd" : @(kAudioChannelLabel_RightSurroundDirect),
+            @"tcs" : @(kAudioChannelLabel_TopCenterSurround),
+            @"vhl" : @(kAudioChannelLabel_VerticalHeightLeft),
+            @"vhc" : @(kAudioChannelLabel_VerticalHeightCenter),
+            @"vhr" : @(kAudioChannelLabel_VerticalHeightRight),
 
-          @"tbl" : @(kAudioChannelLabel_TopBackLeft),
-          @"tbc" : @(kAudioChannelLabel_TopBackCenter),
-          @"tbr" : @(kAudioChannelLabel_TopBackRight),
+            @"tbl" : @(kAudioChannelLabel_TopBackLeft),
+            @"tbc" : @(kAudioChannelLabel_TopBackCenter),
+            @"tbr" : @(kAudioChannelLabel_TopBackRight),
 
-          @"rls" : @(kAudioChannelLabel_RearSurroundLeft),
-          @"rrs" : @(kAudioChannelLabel_RearSurroundRight),
+            @"rls" : @(kAudioChannelLabel_RearSurroundLeft),
+            @"rrs" : @(kAudioChannelLabel_RearSurroundRight),
 
-          @"lw" : @(kAudioChannelLabel_LeftWide),
-          @"rw" : @(kAudioChannelLabel_RightWide),
-      };
+            @"lw" : @(kAudioChannelLabel_LeftWide),
+            @"rw" : @(kAudioChannelLabel_RightWide),
+        };
     });
 
     NSNumber *label = [labels objectForKey:s];


### PR DESCRIPTION
## Pull request overview

This PR adds the `ObjCBlockIndentWidth` configuration option to `.clang-format` and applies the resulting formatting changes to align Objective-C block indentation with the project's standard 4-space indentation.

**Changes:**
- Added `ObjCBlockIndentWidth: 4` to `.clang-format` to standardize Objective-C block indentation
- Reformatted the `dispatch_once` block in `AVAudioChannelLayout+SFBChannelLabels.m` to use 4-space indentation instead of 2