### PR TITLE
Update imports

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -13,7 +13,7 @@ IncludeBlocks: Regroup
 IncludeCategories:
   - Regex: '^".*"$'
     Priority: 1
-  - Regex: '^<(Foundation|AVFAudio)/'
+  - Regex: '^<(Foundation|AudioToolbox|AVFAudio)/'
     Priority: 3
   - Regex: '^<[^./>]+>$'
     Priority: 10

--- a/Sources/AVFAudioExtensions/AVAudioChannelLayout+SFBChannelLabels.m
+++ b/Sources/AVFAudioExtensions/AVAudioChannelLayout+SFBChannelLabels.m
@@ -7,7 +7,7 @@
 
 #import "AVAudioChannelLayout+SFBChannelLabels.h"
 
-@import AudioToolbox.AudioFormat;
+#import <AudioToolbox/AudioFormat.h>
 
 #import <stdlib.h>
 #import <string.h>

--- a/Sources/AVFAudioExtensions/AVAudioChannelLayout+SFBLayoutNames.m
+++ b/Sources/AVFAudioExtensions/AVAudioChannelLayout+SFBLayoutNames.m
@@ -7,7 +7,7 @@
 
 #import "AVAudioChannelLayout+SFBLayoutNames.h"
 
-@import AudioToolbox.AudioFormat;
+#import <AudioToolbox/AudioFormat.h>
 
 static NSString *GetLayoutName(const AudioChannelLayout *layout, BOOL simpleName) {
     NSCParameterAssert(layout != NULL);

--- a/Sources/AVFAudioExtensions/AVAudioFormat+SFBFormatName.m
+++ b/Sources/AVFAudioExtensions/AVAudioFormat+SFBFormatName.m
@@ -7,7 +7,7 @@
 
 #import "AVAudioFormat+SFBFormatName.h"
 
-@import AudioToolbox.AudioFormat;
+#import <AudioToolbox/AudioFormat.h>
 
 #import <stdint.h>
 


### PR DESCRIPTION
## Pull request overview

This PR standardizes import statements by converting from `@import` module syntax to traditional `#import` header syntax for AudioToolbox framework imports.

**Changes:**
- Replaced `@import AudioToolbox.AudioFormat;` with `#import <AudioToolbox/AudioFormat.h>` across three implementation files
- Updated `.clang-format` include category regex to properly recognize and group AudioToolbox imports