### PR TITLE
Add clang-format check workflow

### DIFF
--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -1,0 +1,17 @@
+name: clang-format Check
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+jobs:
+  formatting-check:
+    name: Formatting Check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    - name: Run clang-format
+      uses: jidicula/clang-format-action@v4.16.0
+      with:
+        clang-format-version: '21'
+        check-path: 'Sources'


### PR DESCRIPTION
## Pull request overview

This PR adds a GitHub Actions workflow to automatically check code formatting using clang-format on push and pull request events to the main branch.

**Changes:**
- Added `.github/workflows/clang-format-check.yml` workflow file that runs clang-format version 21 against the Sources directory