### PR TITLE
Add `InsertBraces` to .clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -7,6 +7,8 @@ UseTab: Never
 
 ColumnLimit: 120
 
+InsertBraces: true
+
 ObjCBlockIndentWidth: 4
 
 IncludeBlocks: Regroup

--- a/Sources/AVFAudioExtensions/AVAudioChannelLayout+SFBChannelLabels.m
+++ b/Sources/AVFAudioExtensions/AVAudioChannelLayout+SFBChannelLabels.m
@@ -20,8 +20,9 @@ static size_t GetChannelLayoutSize(UInt32 numberChannelDescriptions) {
 static AudioChannelLayout *CreateChannelLayout(UInt32 numberChannelDescriptions) {
     size_t layoutSize = GetChannelLayoutSize(numberChannelDescriptions);
     AudioChannelLayout *channelLayout = malloc(layoutSize);
-    if (!channelLayout)
+    if (!channelLayout) {
         return NULL;
+    }
 
     memset(channelLayout, 0, layoutSize);
 
@@ -62,8 +63,9 @@ static AudioChannelLabel ChannelLabelForString(NSString *s) {
     });
 
     NSNumber *label = [labels objectForKey:s];
-    if (label != nil)
+    if (label != nil) {
         return (AudioChannelLabel)label.unsignedIntValue;
+    }
     return kAudioChannelLabel_Unknown;
 }
 
@@ -105,11 +107,13 @@ static AudioChannelLabel ChannelLabelForString(NSString *s) {
     NSParameterAssert(ap != NULL);
 
     AudioChannelLabel *channelLabels = malloc(sizeof(AudioChannelLabel) * count);
-    if (!channelLabels)
+    if (!channelLabels) {
         return nil;
+    }
 
-    for (AVAudioChannelCount i = 0; i < count; ++i)
+    for (AVAudioChannelCount i = 0; i < count; ++i) {
         channelLabels[i] = va_arg(ap, AudioChannelLabel);
+    }
 
     self = [self initWithChannelLabels:channelLabels count:count];
     free(channelLabels);
@@ -122,24 +126,27 @@ static AudioChannelLabel ChannelLabelForString(NSString *s) {
     NSParameterAssert(count > 0);
 
     AudioChannelLayout *channelLayout = CreateChannelLayout(count);
-    if (!channelLayout)
+    if (!channelLayout) {
         return nil;
+    }
 
     channelLayout->mChannelLayoutTag = kAudioChannelLayoutTag_UseChannelDescriptions;
     channelLayout->mNumberChannelDescriptions = count;
 
-    for (AVAudioChannelCount i = 0; i < count; ++i)
+    for (AVAudioChannelCount i = 0; i < count; ++i) {
         channelLayout->mChannelDescriptions[i].mChannelLabel = channelLabels[i];
+    }
 
     // Attempt to convert the channel labels to a layout tag
     AudioChannelLayoutTag tag;
     UInt32 dataSize = sizeof(tag);
     OSStatus result = AudioFormatGetProperty(kAudioFormatProperty_TagForChannelLayout,
                                              (UInt32)GetChannelLayoutSize(count), channelLayout, &dataSize, &tag);
-    if (result == noErr)
+    if (result == noErr) {
         self = [self initWithLayoutTag:tag];
-    else
+    } else {
         self = [self initWithLayout:channelLayout];
+    }
 
     free(channelLayout);
 
@@ -154,11 +161,13 @@ static AudioChannelLabel ChannelLabelForString(NSString *s) {
     NSUInteger count = channelLabelArray.count;
 
     AudioChannelLabel *channelLabels = malloc(sizeof(AudioChannelLabel) * count);
-    if (!channelLabels)
+    if (!channelLabels) {
         return nil;
+    }
 
-    for (NSUInteger i = 0; i < count; ++i)
+    for (NSUInteger i = 0; i < count; ++i) {
         channelLabels[i] = ChannelLabelForString([channelLabelArray objectAtIndex:i]);
+    }
 
     self = [self initWithChannelLabels:channelLabels count:(AVAudioChannelCount)count];
     free(channelLabels);

--- a/Sources/AVFAudioExtensions/AVAudioChannelLayout+SFBLayoutNames.m
+++ b/Sources/AVFAudioExtensions/AVAudioChannelLayout+SFBLayoutNames.m
@@ -19,8 +19,9 @@ static NSString *GetLayoutName(const AudioChannelLayout *layout, BOOL simpleName
     CFStringRef name = NULL;
     UInt32 dataSize = sizeof(name);
     OSStatus result = AudioFormatGetProperty(property, layoutSize, layout, &dataSize, &name);
-    if (result != noErr || name == NULL)
+    if (result != noErr || name == NULL) {
         return @"";
+    }
     return (__bridge_transfer NSString *)name;
 }
 

--- a/Sources/AVFAudioExtensions/AVAudioFormat+SFBFormatName.m
+++ b/Sources/AVFAudioExtensions/AVAudioFormat+SFBFormatName.m
@@ -18,8 +18,9 @@
     UInt32 dataSize = sizeof(name);
     OSStatus result = AudioFormatGetProperty(kAudioFormatProperty_FormatName, sizeof(AudioStreamBasicDescription),
                                              self.streamDescription, &dataSize, &name);
-    if (result != noErr || name == NULL)
+    if (result != noErr || name == NULL) {
         return @"";
+    }
     return (__bridge_transfer NSString *)name;
 }
 

--- a/Sources/AVFAudioExtensions/AVAudioFormat+SFBFormatTransformation.m
+++ b/Sources/AVFAudioExtensions/AVAudioFormat+SFBFormatTransformation.m
@@ -11,11 +11,13 @@
 
 - (nullable AVAudioFormat *)nonInterleavedEquivalent {
     AudioStreamBasicDescription asbd = *(self.streamDescription);
-    if (asbd.mFormatID != kAudioFormatLinearPCM || !asbd.mChannelsPerFrame)
+    if (asbd.mFormatID != kAudioFormatLinearPCM || !asbd.mChannelsPerFrame) {
         return nil;
+    }
 
-    if (asbd.mFormatFlags & kAudioFormatFlagIsNonInterleaved)
+    if (asbd.mFormatFlags & kAudioFormatFlagIsNonInterleaved) {
         return self;
+    }
 
     asbd.mFormatFlags |= kAudioFormatFlagIsNonInterleaved;
 
@@ -27,11 +29,13 @@
 
 - (nullable AVAudioFormat *)interleavedEquivalent {
     AudioStreamBasicDescription asbd = *(self.streamDescription);
-    if (asbd.mFormatID != kAudioFormatLinearPCM)
+    if (asbd.mFormatID != kAudioFormatLinearPCM) {
         return nil;
+    }
 
-    if (!(asbd.mFormatFlags & kAudioFormatFlagIsNonInterleaved))
+    if (!(asbd.mFormatFlags & kAudioFormatFlagIsNonInterleaved)) {
         return self;
+    }
 
     asbd.mFormatFlags &= ~kAudioFormatFlagIsNonInterleaved;
 
@@ -42,20 +46,23 @@
 }
 
 - (nullable AVAudioFormat *)standardEquivalent {
-    if (self.isStandard)
+    if (self.isStandard) {
         return self;
-    if (self.channelLayout)
+    }
+    if (self.channelLayout) {
         return [[AVAudioFormat alloc] initStandardFormatWithSampleRate:self.sampleRate
                                                          channelLayout:self.channelLayout];
+    }
     return [[AVAudioFormat alloc] initStandardFormatWithSampleRate:self.sampleRate channels:self.channelCount];
 }
 
 - (nullable AVAudioFormat *)transformedToCommonFormat:(AVAudioCommonFormat)commonFormat interleaved:(BOOL)interleaved {
-    if (self.channelLayout)
+    if (self.channelLayout) {
         return [[AVAudioFormat alloc] initWithCommonFormat:commonFormat
                                                 sampleRate:self.sampleRate
                                                interleaved:interleaved
                                              channelLayout:self.channelLayout];
+    }
     return [[AVAudioFormat alloc] initWithCommonFormat:commonFormat
                                             sampleRate:self.sampleRate
                                               channels:self.channelCount

--- a/Sources/AVFAudioExtensions/AVAudioPCMBuffer+SFBBufferUtilities.m
+++ b/Sources/AVFAudioExtensions/AVAudioPCMBuffer+SFBBufferUtilities.m
@@ -17,8 +17,9 @@
 }
 
 - (AVAudioFrameCount)prependFromBuffer:(AVAudioPCMBuffer *)buffer readingFromOffset:(AVAudioFrameCount)offset {
-    if (offset > buffer.frameLength)
+    if (offset > buffer.frameLength) {
         return 0;
+    }
     return [self insertFromBuffer:buffer readingFromOffset:offset frameLength:(buffer.frameLength - offset) atOffset:0];
 }
 
@@ -33,8 +34,9 @@
 }
 
 - (AVAudioFrameCount)appendFromBuffer:(AVAudioPCMBuffer *)buffer readingFromOffset:(AVAudioFrameCount)offset {
-    if (offset > buffer.frameLength)
+    if (offset > buffer.frameLength) {
         return 0;
+    }
     return [self insertFromBuffer:buffer
                 readingFromOffset:offset
                       frameLength:(buffer.frameLength - offset)
@@ -59,8 +61,9 @@
     NSParameterAssert([self.format isEqual:buffer.format]);
 
     if (readOffset > buffer.frameLength || writeOffset > self.frameLength || frameLength == 0 ||
-        buffer.frameLength == 0)
+        buffer.frameLength == 0) {
         return 0;
+    }
 
     AVAudioFrameCount framesToInsert =
           MIN(self.frameCapacity - self.frameLength, MIN(frameLength, buffer.frameLength - readOffset));
@@ -72,17 +75,19 @@
     AVAudioFrameCount framesToMove = self.frameLength - writeOffset;
     if (framesToMove) {
         AVAudioFrameCount moveToOffset = writeOffset + framesToInsert;
-        for (UInt32 i = 0; i < dst_abl->mNumberBuffers; ++i)
+        for (UInt32 i = 0; i < dst_abl->mNumberBuffers; ++i) {
             memmove((unsigned char *)dst_abl->mBuffers[i].mData + (moveToOffset * asbd->mBytesPerFrame),
                     (const unsigned char *)dst_abl->mBuffers[i].mData + (writeOffset * asbd->mBytesPerFrame),
                     framesToMove * asbd->mBytesPerFrame);
+        }
     }
 
     if (framesToInsert) {
-        for (UInt32 i = 0; i < src_abl->mNumberBuffers; ++i)
+        for (UInt32 i = 0; i < src_abl->mNumberBuffers; ++i) {
             memcpy((unsigned char *)dst_abl->mBuffers[i].mData + (writeOffset * asbd->mBytesPerFrame),
                    (const unsigned char *)src_abl->mBuffers[i].mData + (readOffset * asbd->mBytesPerFrame),
                    framesToInsert * asbd->mBytesPerFrame);
+        }
 
         self.frameLength += framesToInsert;
     }
@@ -101,8 +106,9 @@
 }
 
 - (AVAudioFrameCount)trimAtOffset:(AVAudioFrameCount)offset frameLength:(AVAudioFrameCount)frameLength {
-    if (offset > self.frameLength || frameLength == 0)
+    if (offset > self.frameLength || frameLength == 0) {
         return 0;
+    }
 
     AVAudioFrameCount framesToTrim = MIN(frameLength, self.frameLength - offset);
 
@@ -112,10 +118,11 @@
     AVAudioFrameCount framesToMove = self.frameLength - (offset + framesToTrim);
     if (framesToMove) {
         AVAudioFrameCount moveFromOffset = offset + framesToTrim;
-        for (UInt32 i = 0; i < abl->mNumberBuffers; ++i)
+        for (UInt32 i = 0; i < abl->mNumberBuffers; ++i) {
             memmove((unsigned char *)abl->mBuffers[i].mData + (offset * asbd->mBytesPerFrame),
                     (const unsigned char *)abl->mBuffers[i].mData + (moveFromOffset * asbd->mBytesPerFrame),
                     framesToMove * asbd->mBytesPerFrame);
+        }
     }
 
     self.frameLength -= framesToTrim;
@@ -132,8 +139,9 @@
 }
 
 - (AVAudioFrameCount)insertSilenceAtOffset:(AVAudioFrameCount)offset frameLength:(AVAudioFrameCount)frameLength {
-    if (offset > self.frameLength || frameLength == 0)
+    if (offset > self.frameLength || frameLength == 0) {
         return 0;
+    }
 
     AVAudioFrameCount framesToZero = MIN(self.frameCapacity - self.frameLength, frameLength);
 
@@ -148,16 +156,18 @@
     AVAudioFrameCount framesToMove = self.frameLength - offset;
     if (framesToMove) {
         AVAudioFrameCount moveToOffset = offset + framesToZero;
-        for (UInt32 i = 0; i < abl->mNumberBuffers; ++i)
+        for (UInt32 i = 0; i < abl->mNumberBuffers; ++i) {
             memmove((unsigned char *)abl->mBuffers[i].mData + (moveToOffset * asbd->mBytesPerFrame),
                     (const unsigned char *)abl->mBuffers[i].mData + (offset * asbd->mBytesPerFrame),
                     framesToMove * asbd->mBytesPerFrame);
+        }
     }
 
     if (framesToZero) {
-        for (UInt32 i = 0; i < abl->mNumberBuffers; ++i)
+        for (UInt32 i = 0; i < abl->mNumberBuffers; ++i) {
             memset((unsigned char *)abl->mBuffers[i].mData + (offset * asbd->mBytesPerFrame), 0,
                    framesToZero * asbd->mBytesPerFrame);
+        }
 
         self.frameLength += framesToZero;
     }
@@ -174,8 +184,9 @@
 }
 
 - (BOOL)isDigitalSilence {
-    if (self.frameLength == 0)
+    if (self.frameLength == 0) {
         return YES;
+    }
 
     const AudioStreamBasicDescription *asbd = self.format.streamDescription;
     const AudioBufferList *abl = self.audioBufferList;
@@ -189,8 +200,9 @@
                 const float *buf = (const float *)abl->mBuffers[i].mData;
                 for (UInt32 sampleNumber = 0; sampleNumber < abl->mBuffers[i].mDataByteSize / sizeof(float);
                      ++sampleNumber) {
-                    if (buf[sampleNumber] != 0)
+                    if (buf[sampleNumber] != 0) {
                         return NO;
+                    }
                 }
             }
             return YES;
@@ -200,8 +212,9 @@
                 const double *buf = (const double *)abl->mBuffers[i].mData;
                 for (UInt32 sampleNumber = 0; sampleNumber < abl->mBuffers[i].mDataByteSize / sizeof(double);
                      ++sampleNumber) {
-                    if (buf[sampleNumber] != 0)
+                    if (buf[sampleNumber] != 0) {
                         return NO;
+                    }
                 }
             }
             return YES;
@@ -225,8 +238,9 @@
                     const uint8_t *buf = (const uint8_t *)abl->mBuffers[i].mData;
                     size_t sampleCount = abl->mBuffers[i].mDataByteSize / bytesPerSample;
                     while (sampleCount--) {
-                        if (*buf != silence)
+                        if (*buf != silence) {
                             return NO;
+                        }
                         ++buf;
                     }
                 }
@@ -238,8 +252,9 @@
                     const uint16_t *buf = (const uint16_t *)abl->mBuffers[i].mData;
                     size_t sampleCount = abl->mBuffers[i].mDataByteSize / bytesPerSample;
                     while (sampleCount--) {
-                        if (*buf != silence)
+                        if (*buf != silence) {
                             return NO;
+                        }
                         ++buf;
                     }
                 }
@@ -261,8 +276,9 @@
                             sample |= (*buf++ << 8) & 0xff00;
                             sample |= (*buf++ << 16) & 0xff0000;
                         }
-                        if (sample != silence)
+                        if (sample != silence) {
                             return NO;
+                        }
                     }
                 }
                 return YES;
@@ -273,8 +289,9 @@
                     const uint32_t *buf = (const uint32_t *)abl->mBuffers[i].mData;
                     size_t sampleCount = abl->mBuffers[i].mDataByteSize / bytesPerSample;
                     while (sampleCount--) {
-                        if (*buf != silence)
+                        if (*buf != silence) {
                             return NO;
+                        }
                         ++buf;
                     }
                 }
@@ -286,8 +303,9 @@
                     const uint64_t *buf = (const uint64_t *)abl->mBuffers[i].mData;
                     size_t sampleCount = abl->mBuffers[i].mDataByteSize / bytesPerSample;
                     while (sampleCount--) {
-                        if (*buf != silence)
+                        if (*buf != silence) {
                             return NO;
+                        }
                         ++buf;
                     }
                 }
@@ -308,8 +326,9 @@
                     const uint8_t *buf = (const uint8_t *)abl->mBuffers[i].mData;
                     size_t sampleCount = abl->mBuffers[i].mDataByteSize / bytesPerSample;
                     while (sampleCount--) {
-                        if (*buf != silence)
+                        if (*buf != silence) {
                             return NO;
+                        }
                         ++buf;
                     }
                 }
@@ -325,8 +344,9 @@
                     const uint16_t *buf = (const uint16_t *)abl->mBuffers[i].mData;
                     size_t sampleCount = abl->mBuffers[i].mDataByteSize / bytesPerSample;
                     while (sampleCount--) {
-                        if (*buf != silence)
+                        if (*buf != silence) {
                             return NO;
+                        }
                         ++buf;
                     }
                 }
@@ -352,8 +372,9 @@
                             sample |= (*buf++ << 8) & 0xff00;
                             sample |= (*buf++ << 16) & 0xff0000;
                         }
-                        if (sample != silence)
+                        if (sample != silence) {
                             return NO;
+                        }
                     }
                 }
                 return YES;
@@ -368,8 +389,9 @@
                     const uint32_t *buf = (const uint32_t *)abl->mBuffers[i].mData;
                     size_t sampleCount = abl->mBuffers[i].mDataByteSize / bytesPerSample;
                     while (sampleCount--) {
-                        if (*buf != silence)
+                        if (*buf != silence) {
                             return NO;
+                        }
                         ++buf;
                     }
                 }
@@ -385,8 +407,9 @@
                     const uint64_t *buf = (const uint64_t *)abl->mBuffers[i].mData;
                     size_t sampleCount = abl->mBuffers[i].mDataByteSize / bytesPerSample;
                     while (sampleCount--) {
-                        if (*buf != silence)
+                        if (*buf != silence) {
                             return NO;
+                        }
                         ++buf;
                     }
                 }


### PR DESCRIPTION
## Pull request overview

This PR adds the `InsertBraces: true` configuration option to the `.clang-format` file and applies the formatting rule across all Objective-C implementation files in the codebase. This ensures that all single-statement control flow bodies (if, for, while, etc.) have braces, which is a defensive coding practice that prevents potential bugs.

**Changes:**
- Added `InsertBraces: true` to `.clang-format` configuration
- Applied brace insertion formatting to all existing single-statement control flow statements